### PR TITLE
address minor reviewer comments (docs, CLI, dataclass docstrings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Python-generated files
 __pycache__/
 *.py[oc]
+paper_review.txt
+review_features.md
+review_manuscript.md
 CLAUDE.md
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern Python implementation of the McDonald-Kreitman test toolkit for detecti
 ## Features
 
 - **Standard MK test**: Classic 2x2 contingency table with Fisher's exact test
-- **Polarized MK test**: Uses a third outgroup to assign mutations to lineages
+- **Polarized MK test**: Uses a second outgroup to assign mutations to lineages
 - **Asymptotic MK test**: Frequency-bin α estimates with exponential extrapolation (Messer & Petrov 2013)
 - **Tarone-Greenland α_TG**: Weighted multi-gene estimator that corrects for sample size heterogeneity (Stoletzki & Eyre-Walker 2011)
 - **Alternate genetic codes**: 24 NCBI genetic code tables (mitochondrial, plastid, etc.) selectable by name

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Features
 --------
 
 - **Standard MK test**: Classic 2x2 contingency table with Fisher's exact test
-- **Polarized MK test**: Uses a third outgroup to assign mutations to lineages
+- **Polarized MK test**: Uses a second outgroup to assign mutations to lineages
 - **Asymptotic MK test**: Frequency-bin alpha estimates with exponential extrapolation (`Messer & Petrov 2013`_)
 - **Imputed MK test**: Corrects for slightly deleterious mutations by imputation (`Murga-Moreno et al. 2022`_)
 - **Tarone-Greenland α_TG**: Weighted multi-gene estimator (`Stoletzki & Eyre-Walker 2011`_)

--- a/src/mkado/__init__.py
+++ b/src/mkado/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("mkado")
 except PackageNotFoundError:
-    __version__ = "unknown"
+    __version__ = "0.0.0+unknown"
 
 from mkado.core.sequences import Sequence, SequenceSet
 from mkado.core.codons import GeneticCode

--- a/src/mkado/__init__.py
+++ b/src/mkado/__init__.py
@@ -1,6 +1,11 @@
-"""Mikado: Modern Python implementation of the McDonald-Kreitman test toolkit."""
+"""MKado: Modern Python implementation of the McDonald-Kreitman test toolkit."""
 
-__version__ = "0.3.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("mkado")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 from mkado.core.sequences import Sequence, SequenceSet
 from mkado.core.codons import GeneticCode

--- a/src/mkado/analysis/alpha_tg.py
+++ b/src/mkado/analysis/alpha_tg.py
@@ -27,7 +27,13 @@ from mkado.analysis.asymptotic import PolymorphismData
 
 @dataclass
 class AlphaTGResult:
-    """Results from Tarone-Greenland alpha estimation."""
+    """Results from Tarone-Greenland alpha estimation.
+
+    Per-gene ``(Dn, Ds, Pn, Ps)`` counts follow the standard MK definitions
+    (see :class:`mkado.analysis.mk_test.MKResult`); ``min_frequency``
+    filtering applied to each gene's polymorphism extraction propagates
+    into the totals reported here.
+    """
 
     alpha_tg: float
     """Proportion of adaptive substitutions (1 - NI_TG)."""

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -50,7 +50,14 @@ class AggregatedSFS:
 
 @dataclass
 class AsymptoticMKResult:
-    """Results from an asymptotic McDonald-Kreitman test."""
+    """Results from an asymptotic McDonald-Kreitman test.
+
+    ``Pn_total`` and ``Ps_total`` follow the standard MK definition: ingroup
+    polymorphic sites whose derived allele causes a non-synonymous (Pn) or
+    synonymous (Ps) substitution. The asymptotic test uses the full SFS
+    with no ``min_frequency`` filter; frequency cutoffs apply only to the
+    ``alpha(x)`` curve fit, not to the SFS counts themselves.
+    """
 
     # Frequency bins and alpha estimates
     frequency_bins: list[float] = field(default_factory=list)
@@ -82,11 +89,6 @@ class AsymptoticMKResult:
     # Model type ("exponential" or "linear")
     model_type: str = "exponential"
 
-    # Total polymorphism counts across all bins (sum of the per-bin SFS).
-    # Pn / Ps follow the standard MK definition: ingroup polymorphic sites
-    # whose derived allele causes a non-synonymous (Pn) or synonymous (Ps)
-    # substitution. The asymptotic test uses the full SFS (no min-frequency
-    # filter); frequency cutoffs apply only to the alpha(x) curve fit.
     pn_total: int = 0
     """Total non-synonymous polymorphisms (sum across all SFS bins)."""
     ps_total: int = 0

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -82,9 +82,15 @@ class AsymptoticMKResult:
     # Model type ("exponential" or "linear")
     model_type: str = "exponential"
 
-    # Total polymorphism counts (useful for aggregated results)
+    # Total polymorphism counts across all bins (sum of the per-bin SFS).
+    # Pn / Ps follow the standard MK definition: ingroup polymorphic sites
+    # whose derived allele causes a non-synonymous (Pn) or synonymous (Ps)
+    # substitution. The asymptotic test uses the full SFS (no min-frequency
+    # filter); frequency cutoffs apply only to the alpha(x) curve fit.
     pn_total: int = 0
+    """Total non-synonymous polymorphisms (sum across all SFS bins)."""
     ps_total: int = 0
+    """Total synonymous polymorphisms (sum across all SFS bins)."""
 
     def __str__(self) -> str:
         lines = [

--- a/src/mkado/analysis/imputed.py
+++ b/src/mkado/analysis/imputed.py
@@ -19,20 +19,44 @@ from mkado.analysis.statistics import fishers_exact
 
 @dataclass
 class ImputedMKResult:
-    """Results from an imputed McDonald-Kreitman test."""
+    """Results from an imputed McDonald-Kreitman test.
+
+    The imputed test partitions ``Pn`` into a weakly-deleterious fraction
+    (``Pwd``) — imputed from the synonymous SFS scaled by the observed
+    Pn/Ps ratio at low derived allele frequencies — and a neutral
+    fraction (``Pn_neutral = Pn_total - Pwd``). ``alpha`` is computed
+    against ``Pn_neutral`` rather than the raw ``Pn`` count, removing the
+    downward bias caused by slightly deleterious nonsynonymous variants.
+
+    ``Dn`` and ``Ds`` follow the standard MK definitions. ``Pn_total`` and
+    ``Ps_total`` are the unfiltered ingroup polymorphism counts (the imputed
+    test uses the entire SFS, including singletons).
+    """
 
     alpha: float | None
+    """Proportion of adaptive substitutions, computed against ``Pn_neutral``."""
     p_value: float
+    """Fisher's exact test p-value on the imputed (Dn, Ds, Pn_neutral, Ps_total) table."""
     pn_neutral: float
+    """Estimated neutral nonsynonymous polymorphism count (``Pn_total - Pwd``)."""
     pwd: float
+    """Imputed count of weakly-deleterious nonsynonymous polymorphisms."""
     dn: int
+    """Non-synonymous fixed differences."""
     ds: int
+    """Synonymous fixed differences."""
     pn_total: int
+    """Total non-synonymous ingroup polymorphisms (no frequency filter applied)."""
     ps_total: int
+    """Total synonymous ingroup polymorphisms (no frequency filter applied)."""
     d: float | None = None
+    """Estimated DFE deleterious fraction (Murga-Moreno et al. 2022, eq. 3)."""
     b: float | None = None
+    """Estimated DFE weakly-deleterious fraction."""
     f: float | None = None
+    """Estimated DFE neutral fraction."""
     cutoff: float = 0.15
+    """Derived allele frequency below which polymorphisms are treated as the imputation pool."""
 
     def __str__(self) -> str:
         alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "N/A"

--- a/src/mkado/analysis/mk_test.py
+++ b/src/mkado/analysis/mk_test.py
@@ -17,16 +17,37 @@ if TYPE_CHECKING:
 
 @dataclass
 class MKResult:
-    """Results from a McDonald-Kreitman test."""
+    """Results from a McDonald-Kreitman test.
 
-    dn: int  # Non-synonymous divergence (fixed differences)
-    ds: int  # Synonymous divergence (fixed differences)
-    pn: int  # Non-synonymous polymorphisms
-    ps: int  # Synonymous polymorphisms
-    p_value: float  # Fisher's exact test p-value
-    ni: float | None  # Neutrality Index
-    alpha: float | None  # Proportion of adaptive substitutions
-    dos: float | None  # Direction of Selection
+    Site counts follow the standard MK definitions:
+
+    - **Dn / Ds**: number of fixed differences between ingroup and outgroup
+      that change (Dn) or do not change (Ds) the encoded amino acid under
+      the supplied genetic code.
+    - **Pn / Ps**: number of ingroup polymorphic sites whose derived allele
+      causes a non-synonymous (Pn) or synonymous (Ps) substitution. Sites
+      are filtered by ``min_frequency`` (default ``0.0``); the
+      ``--no-singletons`` CLI flag sets this threshold to ``1/n``. When
+      ``pool_polymorphisms`` is true, polymorphic sites in the outgroup are
+      pooled into the ingroup counts.
+    """
+
+    dn: int
+    """Non-synonymous fixed differences."""
+    ds: int
+    """Synonymous fixed differences."""
+    pn: int
+    """Non-synonymous polymorphisms in the ingroup (after frequency filtering)."""
+    ps: int
+    """Synonymous polymorphisms in the ingroup (after frequency filtering)."""
+    p_value: float
+    """Fisher's exact test p-value on the 2x2 contingency table."""
+    ni: float | None
+    """Neutrality Index ``(Pn/Ps) / (Dn/Ds)``; ``None`` if any count is zero."""
+    alpha: float | None
+    """Proportion of adaptive substitutions ``1 - NI``."""
+    dos: float | None
+    """Direction of Selection ``Dn/(Dn+Ds) - Pn/(Pn+Ps)`` (Stoletzki & Eyre-Walker 2011)."""
 
     def __str__(self) -> str:
         ni_str = f"{self.ni:.4f}" if self.ni is not None else "N/A"

--- a/src/mkado/analysis/polarized.py
+++ b/src/mkado/analysis/polarized.py
@@ -19,31 +19,48 @@ if TYPE_CHECKING:
 class PolarizedMKResult:
     """Results from a polarized McDonald-Kreitman test.
 
-    The polarized test uses a second outgroup to assign mutations to
-    specific lineages (ingroup or first outgroup).
+    The polarized test uses a second outgroup (``outgroup2``) to assign each
+    fixed difference and each ingroup polymorphism to one of two lineages —
+    the ingroup or the first outgroup — by majority rule on the inferred
+    ancestral state. Sites where the ancestral state cannot be determined
+    are reported under ``*_unpolarized``.
+
+    Pn and Ps count derived alleles segregating in the ingroup (subject to
+    ``min_frequency`` filtering, identical to the standard MK test) and
+    are split by lineage assignment.
     """
 
-    # Ingroup lineage counts
     dn_ingroup: int
+    """Non-synonymous fixed differences assigned to the ingroup lineage."""
     ds_ingroup: int
+    """Synonymous fixed differences assigned to the ingroup lineage."""
     pn_ingroup: int
+    """Non-synonymous polymorphisms whose derived allele arose on the ingroup lineage."""
     ps_ingroup: int
+    """Synonymous polymorphisms whose derived allele arose on the ingroup lineage."""
 
-    # Outgroup lineage counts
     dn_outgroup: int
+    """Non-synonymous fixed differences assigned to the first outgroup lineage."""
     ds_outgroup: int
+    """Synonymous fixed differences assigned to the first outgroup lineage."""
 
-    # Unpolarized counts (could not determine lineage)
     dn_unpolarized: int
+    """Non-synonymous fixed differences where lineage could not be determined."""
     ds_unpolarized: int
+    """Synonymous fixed differences where lineage could not be determined."""
     pn_unpolarized: int
+    """Non-synonymous polymorphisms where ancestral state could not be determined."""
     ps_unpolarized: int
+    """Synonymous polymorphisms where ancestral state could not be determined."""
 
-    # Statistics for ingroup lineage
     p_value_ingroup: float
+    """Fisher's exact test p-value on the ingroup-lineage 2x2 table."""
     ni_ingroup: float | None
+    """Neutrality Index for the ingroup lineage."""
     alpha_ingroup: float | None
+    """Proportion of adaptive substitutions on the ingroup lineage."""
     dos_ingroup: float | None
+    """Direction of Selection for the ingroup lineage."""
 
     def __str__(self) -> str:
         ni_str = f"{self.ni_ingroup:.4f}" if self.ni_ingroup is not None else "N/A"

--- a/src/mkado/cli.py
+++ b/src/mkado/cli.py
@@ -49,6 +49,19 @@ def validate_path_not_flag(value: Path | None) -> Path | None:
     return value
 
 
+def write_output(content: str, output_path: Path | None) -> None:
+    """Write formatted result content to a file, or to stdout if no path given.
+
+    A path of ``None`` or ``Path("-")`` means stdout (POSIX convention).
+    """
+    if output_path is None or str(output_path) == "-":
+        typer.echo(content)
+        return
+    text = content if content.endswith("\n") else content + "\n"
+    output_path.write_text(text)
+    typer.echo(f"Output written to {output_path}", err=True)
+
+
 def _collect_gene_data(
     worker_results: list[WorkerResult],
     mode_label: str,
@@ -221,7 +234,10 @@ app = typer.Typer(
     name="mkado",
     help="MKado 御門: McDonald-Kreitman test toolkit.\n\n"
     "A modern Python implementation for detecting selection using "
-    "the McDonald-Kreitman test and related methods.",
+    "the McDonald-Kreitman test and related methods.\n\n"
+    "Shell completion: --install-completion sets up tab completion for "
+    "your shell (bash/zsh/fish/powershell); --show-completion prints the "
+    "completion script without installing it.",
     no_args_is_help=True,
 )
 
@@ -343,6 +359,15 @@ def test(
         typer.Option(
             "--plot-asymptotic",
             help="Generate alpha(x) plot for asymptotic test (PNG, PDF, or SVG)",
+            callback=validate_path_not_flag,
+        ),
+    ] = None,
+    output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-O",
+            help="Write formatted result to this file (default: stdout). Use '-' for stdout.",
             callback=validate_path_not_flag,
         ),
     ] = None,
@@ -622,7 +647,7 @@ def test(
                 genetic_code=genetic_code,
             )
 
-    typer.echo(format_result(result, fmt))
+    write_output(format_result(result, fmt), output)
 
     # Generate asymptotic plot if requested
     if plot_asymptotic and use_asymptotic:
@@ -786,6 +811,15 @@ def batch(
         typer.Option(
             "--plot-asymptotic",
             help="Generate alpha(x) plot for aggregated asymptotic test (PNG, PDF, or SVG)",
+            callback=validate_path_not_flag,
+        ),
+    ] = None,
+    output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-O",
+            help="Write formatted results to this file (default: stdout). Use '-' for stdout.",
             callback=validate_path_not_flag,
         ),
     ] = None,
@@ -981,7 +1015,7 @@ def batch(
                     gene_data=gene_data_list,
                     bootstrap_replicates=bootstrap,
                 )
-                typer.echo(format_result(result, fmt))
+                write_output(format_result(result, fmt), output)
             else:
                 typer.echo("No valid gene data extracted", err=True)
             return
@@ -1008,7 +1042,7 @@ def batch(
                     ci_replicates=bootstrap * 100,
                     frequency_cutoffs=frequency_cutoffs,
                 )
-                typer.echo(format_result(result, fmt))
+                write_output(format_result(result, fmt), output)
 
                 # Generate asymptotic plot if requested
                 if plot_asymptotic:
@@ -1044,7 +1078,7 @@ def batch(
                     gene_data=gene_data_list,
                     cutoff=imputed_cutoff,
                 )
-                typer.echo(format_result(result, fmt))
+                write_output(format_result(result, fmt), output)
             else:
                 typer.echo("No valid gene data extracted", err=True)
             return
@@ -1167,7 +1201,7 @@ def batch(
                     gene_data=gene_data_list,
                     bootstrap_replicates=bootstrap,
                 )
-                typer.echo(format_result(result, fmt))
+                write_output(format_result(result, fmt), output)
             else:
                 typer.echo("No valid gene data extracted", err=True)
             return
@@ -1194,7 +1228,7 @@ def batch(
                     ci_replicates=bootstrap * 100,
                     frequency_cutoffs=frequency_cutoffs,
                 )
-                typer.echo(format_result(result, fmt))
+                write_output(format_result(result, fmt), output)
 
                 # Generate asymptotic plot if requested
                 if plot_asymptotic:
@@ -1230,7 +1264,7 @@ def batch(
                     gene_data=gene_data_list,
                     cutoff=imputed_cutoff,
                 )
-                typer.echo(format_result(result, fmt))
+                write_output(format_result(result, fmt), output)
             else:
                 typer.echo("No valid gene data extracted", err=True)
             return
@@ -1245,7 +1279,7 @@ def batch(
 
     if results:
         adjusted_pvalues = compute_adjusted_pvalues(results)
-        typer.echo(format_batch_results(results, fmt, adjusted_pvalues))
+        write_output(format_batch_results(results, fmt, adjusted_pvalues), output)
 
         # Generate volcano plot if requested
         if volcano:
@@ -1426,6 +1460,15 @@ def vcf(
         bool,
         typer.Option("--verbose", help="Show warnings from htslib/VCF parsing"),
     ] = False,
+    output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-O",
+            help="Write formatted results to this file (default: stdout). Use '-' for stdout.",
+            callback=validate_path_not_flag,
+        ),
+    ] = None,
 ) -> None:
     """Run MK test from VCF + reference + GFF3 annotation.
 
@@ -1641,7 +1684,7 @@ def vcf(
 
     # Single gene mode: output single result
     if gene and len(worker_results) == 1:
-        typer.echo(format_result(worker_results[0].result, fmt))
+        write_output(format_result(worker_results[0].result, fmt), output)
         return
 
     # Alpha TG mode
@@ -1657,7 +1700,7 @@ def vcf(
                 gene_data=gene_data_list,
                 bootstrap_replicates=bootstrap,
             )
-            typer.echo(format_result(result, fmt))
+            write_output(format_result(result, fmt), output)
         else:
             typer.echo("No valid gene data extracted", err=True)
         return
@@ -1674,7 +1717,7 @@ def vcf(
                 ci_replicates=bootstrap * 100,
                 frequency_cutoffs=frequency_cutoffs,
             )
-            typer.echo(format_result(result, fmt))
+            write_output(format_result(result, fmt), output)
             if plot_asymptotic:
                 from mkado.io.plotting import create_asymptotic_plot
 
@@ -1698,7 +1741,7 @@ def vcf(
                 gene_data=gene_data_list,
                 cutoff=imputed_cutoff,
             )
-            typer.echo(format_result(result, fmt))
+            write_output(format_result(result, fmt), output)
         else:
             typer.echo("No valid gene data extracted", err=True)
         return
@@ -1724,7 +1767,7 @@ def vcf(
 
     if results_list:
         adjusted_pvalues = compute_adjusted_pvalues(results_list)
-        typer.echo(format_batch_results(results_list, fmt, adjusted_pvalues))
+        write_output(format_batch_results(results_list, fmt, adjusted_pvalues), output)
 
         # Generate volcano plot if requested
         if volcano:

--- a/src/mkado/cli.py
+++ b/src/mkado/cli.py
@@ -49,17 +49,30 @@ def validate_path_not_flag(value: Path | None) -> Path | None:
     return value
 
 
+STDOUT_PATH = Path("-")
+
+OutputOption = Annotated[
+    Optional[Path],
+    typer.Option(
+        "--output",
+        "-O",
+        help="Write formatted results to this file (default: stdout). Use '-' for stdout.",
+        callback=validate_path_not_flag,
+    ),
+]
+
+
 def write_output(content: str, output_path: Path | None) -> None:
     """Write formatted result content to a file, or to stdout if no path given.
 
     A path of ``None`` or ``Path("-")`` means stdout (POSIX convention).
     """
-    if output_path is None or str(output_path) == "-":
+    if output_path is None or output_path == STDOUT_PATH:
         typer.echo(content)
         return
     text = content if content.endswith("\n") else content + "\n"
     output_path.write_text(text)
-    typer.echo(f"Output written to {output_path}", err=True)
+    typer.echo(f"Results saved to {output_path}", err=True)
 
 
 def _collect_gene_data(
@@ -362,15 +375,7 @@ def test(
             callback=validate_path_not_flag,
         ),
     ] = None,
-    output: Annotated[
-        Optional[Path],
-        typer.Option(
-            "--output",
-            "-O",
-            help="Write formatted result to this file (default: stdout). Use '-' for stdout.",
-            callback=validate_path_not_flag,
-        ),
-    ] = None,
+    output: OutputOption = None,
 ) -> None:
     """Run McDonald-Kreitman test on a single alignment.
 
@@ -814,15 +819,7 @@ def batch(
             callback=validate_path_not_flag,
         ),
     ] = None,
-    output: Annotated[
-        Optional[Path],
-        typer.Option(
-            "--output",
-            "-O",
-            help="Write formatted results to this file (default: stdout). Use '-' for stdout.",
-            callback=validate_path_not_flag,
-        ),
-    ] = None,
+    output: OutputOption = None,
 ) -> None:
     """Run MK test on multiple alignment files.
 
@@ -1460,15 +1457,7 @@ def vcf(
         bool,
         typer.Option("--verbose", help="Show warnings from htslib/VCF parsing"),
     ] = False,
-    output: Annotated[
-        Optional[Path],
-        typer.Option(
-            "--output",
-            "-O",
-            help="Write formatted results to this file (default: stdout). Use '-' for stdout.",
-            callback=validate_path_not_flag,
-        ),
-    ] = None,
+    output: OutputOption = None,
 ) -> None:
     """Run MK test from VCF + reference + GFF3 annotation.
 

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mkado"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cyvcf2" },


### PR DESCRIPTION
## Summary

Addresses the trivial/cleanup-grade reviewer feedback that doesn't need its own issue. The substantive feature requests are tracked separately as #8 (cumulative SFS), #9 (Ls/Ln + omega_a/omega_na), #10 (multinomial bootstrap CI), and #11 (aggregated runtime benchmark).

## Changes

- **Docs wording fix.** Reviewer 2 noted "third outgroup" is incorrect — the polarized MK test sees the ingroup, outgroup1, and outgroup2 (two outgroups). Fixed in \`docs/index.rst\` and \`README.md\`.
- **Package metadata.** \`src/mkado/__init__.py\` was still on \`__version__ = \"0.3.0\"\` and the \"Mikado\" docstring. Now sources the version from \`importlib.metadata.version(\"mkado\")\` so it can't drift from \`pyproject.toml\` again.
- **Pn / Ps definitions.** Reviewer 2 noted Dn / Ds are clearly defined but Pn / Ps are not. Each result dataclass (\`MKResult\`, \`PolarizedMKResult\`, \`AsymptoticMKResult\`, \`ImputedMKResult\`, \`AlphaTGResult\`) now has class-level prose defining Pn / Ps for that specific test, and per-field docstrings replacing the previous inline \`#\` comments.
- **\`--output\` / \`-O\` flag.** Reviewer 2 noted there was no way to redirect command output to a named file. Added on \`test\`, \`batch\`, and \`vcf\`. Path \`-\` explicitly means stdout. Behavior is unchanged when the flag is omitted.
- **Shell completion help text.** Reviewer 2 noted the umbrella \`--install-completion\` / \`--show-completion\` options were unexplained. Added a paragraph to the umbrella help.

## Test plan

- [x] \`pytest\` — 215/215 passing
- [x] \`ruff check\` clean on all touched files
- [x] \`mkado --help\` shows the new shell-completion paragraph
- [x] \`mkado test/batch/vcf --help\` show the new \`--output\`/\`-O\` flag
- [x] \`python -c \"import mkado; print(mkado.__version__)\"\` reports \`0.4.0\` (sourced from pyproject)