### PR TITLE
Expose Ls/Ln, omega, omega_a, omega_na with bootstrap CIs (closes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
   per-gene Smith-Eyre-Walker / polarized alpha is too noisy for a
   meaningful rate decomposition. See `docs/omega.rst` for the
   rationale.
+- 95% confidence intervals on the omega decomposition where a sampling
+  procedure is already available. `AsymptoticMKResult` exposes
+  `omega_a_ci_low`/`omega_a_ci_high` and `omega_na_ci_low`/`omega_na_ci_high`
+  by scaling the existing alpha CI (Dn/Ds/Ln/Ls are constants under the
+  asymptotic Monte Carlo, so omega itself has no sampling distribution).
+  `AlphaTGResult` recomputes omega/omega_a/omega_na per gene-resampled
+  bootstrap replicate and reports `omega_ci_low/high`,
+  `omega_a_ci_low/high`, `omega_na_ci_low/high` from the percentile
+  distribution. `ImputedMKResult` does not (yet) bootstrap and reports
+  point estimates only.
 - `omega_decomposition()` helper in `mkado.analysis.statistics`.
 - `AlignedPair.count_total_sites()` aggregating Nei-Gojobori `(Ln, Ls)`
   totals over analyzed codons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Nei-Gojobori site totals on every result dataclass (`MKResult`,
+  `AsymptoticMKResult`, `PolarizedMKResult`, `ImputedMKResult`,
+  `AlphaTGResult`) as `ln` and `ls` fields. Aggregated and per-gene
+  paths populate them automatically from analyzed codons.
+- `omega` (dN/dS, with Nei-Gojobori site weighting) on every result
+  dataclass: `omega = (Dn/Ds) * (Ls/Ln)`. Returns `None` when `Ds = 0`
+  or site counts are unavailable.
+- `omega_a` and `omega_na` (adaptive / non-adaptive substitution rates)
+  on result types whose alpha estimator is appropriate for the
+  decomposition: `AsymptoticMKResult` (per-gene and aggregated),
+  `ImputedMKResult`, and `AlphaTGResult`. Following Gossmann, Keightley
+  & Eyre-Walker (2012, *Genome Biol Evol* 4(5):658-667),
+  `omega_a = alpha * omega` and `omega_na = (1 - alpha) * omega`.
+  `MKResult` and `PolarizedMKResult` deliberately omit these — the
+  per-gene Smith-Eyre-Walker / polarized alpha is too noisy for a
+  meaningful rate decomposition. See `docs/omega.rst` for the
+  rationale.
+- `omega_decomposition()` helper in `mkado.analysis.statistics`.
+- `AlignedPair.count_total_sites()` aggregating Nei-Gojobori `(Ln, Ls)`
+  totals over analyzed codons.
+- `Ln`, `Ls`, `omega`, `omega_a`, and `omega_na` columns in pretty,
+  TSV, and JSON output for all result types.
+
 ## [0.4.0] - 2026-03-17
 
 ### Added

--- a/docs/alpha-tg.rst
+++ b/docs/alpha-tg.rst
@@ -62,6 +62,8 @@ The output includes:
 - **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals
 - **omega**: dN/dS ratio ``(Dn/Ds) * (Ls/Ln)``
 - **omega_a, omega_na**: Adaptive and non-adaptive substitution rates
+  (`Gossmann, Keightley & Eyre-Walker 2012`_; applied to MK counts by
+  `Coronado-Zamora et al. 2019`_)
 - **omega_CI_low/high, omega_a_CI_low/high, omega_na_CI_low/high**:
   95% bootstrap CIs. Because the gene-resampling bootstrap varies Dn, Ds,
   Ln, and Ls per replicate, omega itself has a bootstrap distribution here
@@ -140,5 +142,11 @@ Reference
 ---------
 
 .. _Stoletzki & Eyre-Walker (2011): https://doi.org/10.1093/molbev/msq249
+.. _Gossmann, Keightley & Eyre-Walker 2012: https://doi.org/10.1093/gbe/evs027
+.. _Coronado-Zamora et al. 2019: https://doi.org/10.1093/gbe/evz046
 
 Stoletzki N, Eyre-Walker A (2011) Estimation of the Neutrality Index. *Molecular Biology and Evolution* 28(1):63-70. https://doi.org/10.1093/molbev/msq249
+
+Gossmann TI, Keightley PD, Eyre-Walker A (2012) The effect of variation in the effective population size on the rate of adaptive molecular evolution in eukaryotes. *Genome Biology and Evolution* 4(5):658-667. https://doi.org/10.1093/gbe/evs027
+
+Coronado-Zamora M, Salvador-Martínez I, Castellano D, Barbadilla A, Salazar-Ciudad I (2019) Adaptation and conservation throughout the *Drosophila melanogaster* life-cycle. *Genome Biology and Evolution* 11(5):1463-1482. https://doi.org/10.1093/gbe/evz046

--- a/docs/alpha-tg.rst
+++ b/docs/alpha-tg.rst
@@ -56,16 +56,24 @@ The output includes:
 
 - **alpha_TG**: Proportion of adaptive substitutions (1 - NI_TG)
 - **NI_TG**: The weighted neutrality index
-- **CI_low, CI_high**: 95% bootstrap confidence interval
+- **CI_low, CI_high**: 95% bootstrap confidence interval on alpha_TG
 - **num_genes**: Number of genes analyzed
 - **Dn, Ds, Pn, Ps**: Total counts across all genes
+- **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals
+- **omega**: dN/dS ratio ``(Dn/Ds) * (Ls/Ln)``
+- **omega_a, omega_na**: Adaptive and non-adaptive substitution rates
+- **omega_CI_low/high, omega_a_CI_low/high, omega_na_CI_low/high**:
+  95% bootstrap CIs. Because the gene-resampling bootstrap varies Dn, Ds,
+  Ln, and Ls per replicate, omega itself has a bootstrap distribution here
+  (unlike in the asymptotic test where Ln/Ls are constants). See
+  :doc:`omega` for the rationale.
 
-Example output (TSV format):
+Example output (TSV format, abbreviated):
 
 .. code-block:: text
 
-   Dn      Ds      Pn    Ps      alpha_TG  NI_TG     CI_low    CI_high   num_genes
-   18828   49857   7843  25083   0.022781  0.977219  -0.053529 0.088672  400
+   Dn      Ds      Pn    Ps      alpha_TG  NI_TG     CI_low    CI_high   num_genes  ...  omega    omega_a  omega_na  omega_CI_low  omega_CI_high  ...
+   18828   49857   7843  25083   0.022781  0.977219  -0.053529 0.088672  400        ...  0.1117   0.0025   0.1092    0.1075        0.1158         ...
 
 Comparison with Other Methods
 -----------------------------

--- a/docs/asymptotic.rst
+++ b/docs/asymptotic.rst
@@ -143,7 +143,9 @@ The asymptotic test reports:
 - **a, b, c**: Fitted model parameters (c only for exponential)
 - **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals
 - **omega**: dN/dS ratio ``(Dn/Ds) * (Ls/Ln)``
-- **omega_a, omega_na**: Adaptive and non-adaptive substitution rates (Gossmann, Keightley & Eyre-Walker 2012)
+- **omega_a, omega_na**: Adaptive and non-adaptive substitution rates
+  (`Gossmann, Keightley & Eyre-Walker 2012`_; applied to MK counts by
+  `Coronado-Zamora et al. 2019`_)
 - **omega_a_CI_low/high, omega_na_CI_low/high**: 95% CIs derived analytically by scaling the alpha CI by omega (omega_na percentiles flip since ``(1 - alpha)`` is monotonically decreasing). See :doc:`omega` for the rationale.
 
 Example output (pretty format):
@@ -251,7 +253,13 @@ References
 
 .. _Haller & Messer 2017: https://doi.org/10.1534/g3.117.039693
 .. _Messer & Petrov (2013): https://doi.org/10.1073/pnas.1220835110
+.. _Gossmann, Keightley & Eyre-Walker 2012: https://doi.org/10.1093/gbe/evs027
+.. _Coronado-Zamora et al. 2019: https://doi.org/10.1093/gbe/evz046
 
 Haller BC, Messer PW (2017) asymptoticMK: A web-based tool for the asymptotic McDonald–Kreitman test. *G3: Genes, Genomes, Genetics* 7(5):1569-1575. https://doi.org/10.1534/g3.117.039693
 
 Messer PW, Petrov DA (2013) Frequent adaptation and the McDonald–Kreitman test. *PNAS* 110(21):8615-8620. https://doi.org/10.1073/pnas.1220835110
+
+Gossmann TI, Keightley PD, Eyre-Walker A (2012) The effect of variation in the effective population size on the rate of adaptive molecular evolution in eukaryotes. *Genome Biology and Evolution* 4(5):658-667. https://doi.org/10.1093/gbe/evs027
+
+Coronado-Zamora M, Salvador-Martínez I, Castellano D, Barbadilla A, Salazar-Ciudad I (2019) Adaptation and conservation throughout the *Drosophila melanogaster* life-cycle. *Genome Biology and Evolution* 11(5):1463-1482. https://doi.org/10.1093/gbe/evz046

--- a/docs/asymptotic.rst
+++ b/docs/asymptotic.rst
@@ -141,17 +141,24 @@ The asymptotic test reports:
 - **CI_low, CI_high**: 95% bootstrap confidence interval
 - **model_type**: Selected model (exponential or linear)
 - **a, b, c**: Fitted model parameters (c only for exponential)
+- **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals
+- **omega**: dN/dS ratio ``(Dn/Ds) * (Ls/Ln)``
+- **omega_a, omega_na**: Adaptive and non-adaptive substitution rates (Gossmann, Keightley & Eyre-Walker 2012)
+- **omega_a_CI_low/high, omega_na_CI_low/high**: 95% CIs derived analytically by scaling the alpha CI by omega (omega_na percentiles flip since ``(1 - alpha)`` is monotonically decreasing). See :doc:`omega` for the rationale.
 
 Example output (pretty format):
 
 .. code-block:: text
 
    Asymptotic MK Test Results:
-     Divergence:    Dn=18828, Ds=49857
-     Polymorphism:  Pn=7843, Ps=25083
-     Alpha (asymptotic): 0.5723
-     95% CI: [0.4879, 0.6567]
-     Model: exponential
+     Asymptotic α: 0.5723 (95% CI: 0.4879 - 0.6567)
+     Divergence: Dn=18828, Ds=49857
+     Polymorphism: Pn=7843, Ps=25083
+     Sites: Ln=42137.50, Ls=14752.83
+     omega: 0.2189 (omega_a=0.1252, omega_na=0.0936)
+       omega_a 95% CI:  (0.1068, 0.1437)
+       omega_na 95% CI: (0.0751, 0.1119)
+     Fit (exponential): α(x) = 0.6612 + (-0.4521) * exp(-3.214 * x)
 
 The Alpha(x) Plot
 -----------------

--- a/docs/imputed.rst
+++ b/docs/imputed.rst
@@ -123,9 +123,11 @@ The imputed test reports:
 - **cutoff**: The DAF cutoff used
 - **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals
 - **omega, omega_a, omega_na**: dN/dS and the adaptive/non-adaptive
-  decomposition (``omega_a = alpha * omega``). Reported as point
-  estimates only — the imputed test does not currently bootstrap, so
-  no CIs are produced. See :doc:`omega` for the decomposition formula.
+  decomposition (``omega_a = alpha * omega``) following
+  `Gossmann, Keightley & Eyre-Walker 2012`_, applied to MK counts by
+  `Coronado-Zamora et al. 2019`_. Reported as point estimates only — the
+  imputed test does not currently bootstrap, so no CIs are produced.
+  See :doc:`omega` for the decomposition formula.
 
 Example output (pretty format):
 
@@ -210,5 +212,11 @@ Reference
 ---------
 
 .. _Murga-Moreno et al. (2022): https://doi.org/10.1093/g3journal/jkac206
+.. _Gossmann, Keightley & Eyre-Walker 2012: https://doi.org/10.1093/gbe/evs027
+.. _Coronado-Zamora et al. 2019: https://doi.org/10.1093/gbe/evz046
 
 Murga-Moreno J, Coronado-Zamora M, Casillas S, Barbadilla A (2022) impMKT: the imputed McDonald and Kreitman test, a straightforward correction that significantly increases the evidence of positive selection of the McDonald and Kreitman test at the gene level. *G3: Genes, Genomes, Genetics* 12(10):jkac206. https://doi.org/10.1093/g3journal/jkac206
+
+Gossmann TI, Keightley PD, Eyre-Walker A (2012) The effect of variation in the effective population size on the rate of adaptive molecular evolution in eukaryotes. *Genome Biology and Evolution* 4(5):658-667. https://doi.org/10.1093/gbe/evs027
+
+Coronado-Zamora M, Salvador-Martínez I, Castellano D, Barbadilla A, Salazar-Ciudad I (2019) Adaptation and conservation throughout the *Drosophila melanogaster* life-cycle. *Genome Biology and Evolution* 11(5):1463-1482. https://doi.org/10.1093/gbe/evz046

--- a/docs/imputed.rst
+++ b/docs/imputed.rst
@@ -121,6 +121,11 @@ The imputed test reports:
 - **Pn_neutral**: Nonsynonymous polymorphisms after removing imputed slightly deleterious mutations
 - **Dn, Ds, Pn, Ps**: Raw counts
 - **cutoff**: The DAF cutoff used
+- **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals
+- **omega, omega_a, omega_na**: dN/dS and the adaptive/non-adaptive
+  decomposition (``omega_a = alpha * omega``). Reported as point
+  estimates only — the imputed test does not currently bootstrap, so
+  no CIs are produced. See :doc:`omega` for the decomposition formula.
 
 Example output (pretty format):
 
@@ -134,6 +139,8 @@ Example output (pretty format):
      Pn (neutral):  6.18
      Alpha:         0.5154
      p-value:       0.0891
+     Sites:         Ln=576.00, Ls=195.00
+     omega:         0.2539 (omega_a=0.1308, omega_na=0.1230)
 
 Comparison with Other Methods
 -----------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Features
 - **Asymptotic MK test**: Frequency-bin alpha estimates with exponential extrapolation (`Messer & Petrov 2013`_)
 - **Imputed MK test**: Corrects for slightly deleterious mutations by imputation (`Murga-Moreno et al. 2022`_)
 - **Tarone-Greenland α_TG**: Weighted multi-gene estimator (`Stoletzki & Eyre-Walker 2011`_)
+- **Omega decomposition**: dN/dS plus adaptive (ω_a) / non-adaptive (ω_na) rates with 95% CIs (`Gossmann, Keightley & Eyre-Walker 2012`_)
 - **Alternate genetic codes**: Support for 24 NCBI genetic code tables (mitochondrial, plastid, etc.)
 - **VCF input**: Go directly from VCF + reference + GFF3 to MK test results
 - **Batch processing**: Process multiple genes with parallel execution
@@ -71,3 +72,4 @@ Indices and tables
 .. _Messer & Petrov 2013: https://doi.org/10.1073/pnas.1220835110
 .. _Murga-Moreno et al. 2022: https://doi.org/10.1093/g3journal/jkac206
 .. _Stoletzki & Eyre-Walker 2011: https://doi.org/10.1093/molbev/msq249
+.. _Gossmann, Keightley & Eyre-Walker 2012: https://doi.org/10.1093/gbe/evs027

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ Quick Example
    imputed
    alpha-tg
    dos
+   omega
    file-formats
    api
 

--- a/docs/omega.rst
+++ b/docs/omega.rst
@@ -112,6 +112,45 @@ If you need a per-gene ω_a estimate with proper uncertainty quantification,
 consider the SnIPRE Bayesian hierarchical estimator (`Eilertson et al. 2012`_)
 — not currently implemented in MKado.
 
+Confidence intervals
+--------------------
+
+For result types that already perform a sampling procedure to estimate α,
+MKado also reports 95% CIs on ω_a and ω_na (and on ω itself where it has a
+sampling distribution):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 25 25
+
+   * - Result type
+     - ω CI
+     - ω_a CI
+     - ω_na CI
+   * - ``AsymptoticMKResult``
+     - n/a (constant)
+     - ``α_CI × ω``
+     - ``(1 − α_CI) × ω`` (flipped)
+   * - ``AlphaTGResult``
+     - bootstrap
+     - bootstrap
+     - bootstrap
+
+For ``AsymptoticMKResult`` the asymptotic-fit Monte Carlo (or exponential-fit
+bootstrap) only resamples polymorphisms — Dn, Ds, Ln, Ls are constants of the
+alignment. ω therefore has no sampling distribution and is reported as a
+point estimate. The CIs on ω_a and ω_na are derived analytically by scaling
+the α CI (``ω_a_ci_low = α_ci_low × ω``, etc.); the ω_na percentiles flip
+because ``(1 − α)`` is monotonically decreasing in α.
+
+For ``AlphaTGResult`` the bootstrap resamples genes, so Dn, Ds, Ln, Ls all
+vary per replicate and ω has its own bootstrap distribution. ω, ω_a, and
+ω_na are recomputed per replicate and 2.5%/97.5% percentiles taken.
+
+ImputedMKResult does not currently report CIs on ω_a / ω_na — the imputed
+test produces a single point estimate. If you need CIs there, consider
+running the imputed test on bootstrap replicates of the input alignment.
+
 Edge cases
 ----------
 

--- a/docs/omega.rst
+++ b/docs/omega.rst
@@ -3,7 +3,11 @@ Omega Decomposition (ω, ω_a, ω_na)
 
 MKado reports the rate of nonsynonymous substitution per site (ω), and where
 appropriate, its decomposition into adaptive (ω_a) and non-adaptive (ω_na)
-components following `Gossmann, Keightley & Eyre-Walker (2012)`_.
+components. The decomposition was introduced by
+`Gossmann, Keightley & Eyre-Walker (2012)`_ and applied in the
+McDonald-Kreitman context — the same form MKado uses — by
+`Coronado-Zamora et al. (2019)`_ in their analysis of selection across the
+*Drosophila* life cycle.
 
 Background
 ----------
@@ -15,9 +19,15 @@ argue, comparing α between species or genomic regions is misleading when the
 underlying neutral substitution rate varies. The authors recommend reporting
 ω_a — the rate of adaptive substitution per site, scaled by the synonymous
 substitution rate — as a more appropriate cross-comparison statistic.
+`Coronado-Zamora et al. (2019)`_ later applied the same decomposition
+directly to MK-style fixed/polymorphic counts (the form MKado computes),
+showing how ω_a and ω_na partition the substitution rate into adaptive and
+slightly-deleterious components across functional categories.
 
 The decomposition
 -----------------
+
+Following `Coronado-Zamora et al. (2019)`_:
 
 .. math::
 

--- a/docs/omega.rst
+++ b/docs/omega.rst
@@ -1,0 +1,156 @@
+Omega Decomposition (ω, ω_a, ω_na)
+===================================
+
+MKado reports the rate of nonsynonymous substitution per site (ω), and where
+appropriate, its decomposition into adaptive (ω_a) and non-adaptive (ω_na)
+components following `Gossmann, Keightley & Eyre-Walker (2012)`_.
+
+Background
+----------
+
+The classical McDonald-Kreitman summary statistics (α, NI, DoS) are
+*proportions* — they describe what fraction of substitutions were adaptive,
+but not the *rate* at which adaptation occurs. As `Gossmann et al. (2012)`_
+argue, comparing α between species or genomic regions is misleading when the
+underlying neutral substitution rate varies. The authors recommend reporting
+ω_a — the rate of adaptive substitution per site, scaled by the synonymous
+substitution rate — as a more appropriate cross-comparison statistic.
+
+The decomposition
+-----------------
+
+.. math::
+
+   \omega    &= \frac{D_n}{D_s} \cdot \frac{L_s}{L_n} \\
+   \omega_a  &= \alpha \cdot \omega \\
+   \omega_{na} &= (1 - \alpha) \cdot \omega = \omega - \omega_a
+
+Where:
+
+- :math:`D_n, D_s` — nonsynonymous and synonymous fixed differences
+- :math:`L_n, L_s` — nonsynonymous and synonymous site totals (Nei-Gojobori
+  averaged across analyzed codons in both groups)
+- :math:`\alpha` — proportion of adaptive substitutions
+
+ω = (Dn × Ls) / (Ds × Ln) is the standard dN/dS ratio with Nei-Gojobori
+site weighting; ω_a is the adaptive-substitution rate per synonymous site;
+ω_na is its complement.
+
+Site counting
+-------------
+
+MKado computes :math:`L_n` and :math:`L_s` with the **Nei-Gojobori (1986)**
+method: for each clean codon, count the fraction of single-nucleotide
+substitutions at each site that would be synonymous, sum across the three
+codon positions, and average across all clean codons in both ingroup and
+outgroup at each analyzed position.
+
+.. note::
+
+   `Gossmann et al. (2012)`_ used the F3×4 codon-frequency model implemented in
+   PAML, not Nei-Gojobori. The two methods give numerically different site
+   counts, so MKado's ω, ω_a, and ω_na are **not strictly comparable** to
+   numbers reported under the F3×4 convention. The decomposition itself
+   (α × ω) is identical; the difference is in how :math:`L_n` and :math:`L_s`
+   are estimated.
+
+When ω_a / ω_na are reported (and when they are not)
+-----------------------------------------------------
+
+ω is well-defined and well-behaved per gene: it is the standard dN/dS ratio,
+routinely reported per-gene by tools like PAML's codeml. MKado therefore
+reports ω on every result type.
+
+ω_a and ω_na, by contrast, **inherit the variance of α**. Per-gene Smith &
+Eyre-Walker α is known to be noisy on the small Dn/Ds/Pn/Ps counts typical
+of a single gene; multiplying by ω propagates that noise into ω_a. Following
+the convention of `Gossmann et al. (2012)`_, `Galtier (2016)`_, and
+`Coronado-Zamora et al. (2019)`_, MKado therefore restricts ω_a / ω_na to
+result types whose α estimator is appropriate for the decomposition:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 15 35
+
+   * - Result type
+     - ω
+     - ω_a / ω_na
+     - α estimator feeding ω_a
+   * - ``MKResult`` (per-gene MK)
+     - ✓
+     - ✗
+     - per-gene Smith-Eyre-Walker α
+   * - ``PolarizedMKResult`` (per-gene)
+     - ✓
+     - ✗
+     - per-gene polarized α
+   * - ``AsymptoticMKResult`` (per-gene)
+     - ✓
+     - ✓
+     - asymptotic α (`Messer & Petrov 2013`_)
+   * - ``AsymptoticMKResult`` (aggregated)
+     - ✓
+     - ✓
+     - asymptotic α — **canonical Gossmann-style ω_a**
+   * - ``ImputedMKResult``
+     - ✓
+     - ✓
+     - imputed α (`Murga-Moreno et al. 2022`_)
+   * - ``AlphaTGResult``
+     - ✓
+     - ✓
+     - Tarone-Greenland weighted α
+
+Rationale: per-gene Smith-Eyre-Walker α is noisy because Dn, Ds, Pn, Ps
+counts on a single gene are typically small. Multiplying that noisy α by ω
+produces a ω_a whose variance is dominated by α-variance, not by any
+biological signal. The asymptotic, Tarone-Greenland, and imputed estimators
+were designed for use with sparse counts and are explicitly intended for
+this kind of decomposition.
+
+If you need a per-gene ω_a estimate with proper uncertainty quantification,
+consider the SnIPRE Bayesian hierarchical estimator (`Eilertson et al. 2012`_)
+— not currently implemented in MKado.
+
+Edge cases
+----------
+
+ω, ω_a, and ω_na return ``None`` (rendered as ``NA`` in TSV, ``null`` in JSON)
+when:
+
+- :math:`D_s = 0` — denominator undefined
+- :math:`L_s = 0` or :math:`L_n = 0` — site counts undefined
+- :math:`L_n` / :math:`L_s` were not computed (e.g. legacy
+  ``mk_test_from_counts()`` calls without the ``ln`` / ``ls`` arguments)
+
+Additionally, ω_a and ω_na are ``None`` when α is ``None`` — typically when
+:math:`D_n = 0` or :math:`P_s = 0`.
+
+References
+----------
+
+.. _Gossmann, Keightley & Eyre-Walker (2012): https://doi.org/10.1093/gbe/evs027
+.. _Gossmann et al. (2012): https://doi.org/10.1093/gbe/evs027
+.. _Galtier (2016): https://doi.org/10.1371/journal.pgen.1005774
+.. _Coronado-Zamora et al. (2019): https://doi.org/10.1093/gbe/evz046
+.. _Messer & Petrov 2013: https://doi.org/10.1073/pnas.1220835110
+.. _Murga-Moreno et al. 2022: https://doi.org/10.1093/g3journal/jkac206
+.. _Eilertson et al. 2012: https://doi.org/10.1371/journal.pgen.1002806
+
+Gossmann TI, Keightley PD, Eyre-Walker A (2012). The effect of variation in
+the effective population size on the rate of adaptive molecular evolution
+in eukaryotes. *Genome Biology and Evolution* 4(5):658-667.
+https://doi.org/10.1093/gbe/evs027
+
+Coronado-Zamora M, Salvador-Martínez I, Castellano D, Barbadilla A, Salazar-Ciudad I (2019).
+Adaptation and conservation throughout the *Drosophila melanogaster* life-cycle.
+*Genome Biology and Evolution* 11(5):1463-1482.
+https://doi.org/10.1093/gbe/evz046
+
+Galtier N (2016). Adaptive protein evolution in animals and the effective
+population size hypothesis. *PLoS Genetics* 12(1):e1005774.
+https://doi.org/10.1371/journal.pgen.1005774
+
+Nei M, Gojobori T (1986). Simple methods for estimating the numbers of
+synonymous and nonsynonymous nucleotide substitutions. *Molecular Biology
+and Evolution* 3(5):418-426.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -141,6 +141,9 @@ The output includes:
 - **95% CI**: Confidence interval for alpha asymptotic
 - **Model type**: Whether exponential or linear model was selected
 - **Per-bin alpha values**: Alpha estimates at each frequency class
+- **omega, omega_a, omega_na**: dN/dS and its adaptive / non-adaptive
+  decomposition, with 95% CIs on omega_a and omega_na derived by scaling
+  the alpha CI. See :doc:`omega` for details.
 
 Allele Polarization
 -------------------

--- a/src/mkado/analysis/alpha_tg.py
+++ b/src/mkado/analysis/alpha_tg.py
@@ -73,6 +73,18 @@ class AlphaTGResult:
     """Adaptive rate ``alpha_tg * omega`` (Gossmann, Keightley & Eyre-Walker 2012)."""
     omega_na: float | None = None
     """Non-adaptive component ``(1 - alpha_tg) * omega``."""
+    omega_ci_low: float | None = None
+    """Lower 95% bootstrap CI for ``omega`` (gene-level resampling varies Dn, Ds, Ln, Ls)."""
+    omega_ci_high: float | None = None
+    """Upper 95% bootstrap CI for ``omega``."""
+    omega_a_ci_low: float | None = None
+    """Lower 95% bootstrap CI for ``omega_a``."""
+    omega_a_ci_high: float | None = None
+    """Upper 95% bootstrap CI for ``omega_a``."""
+    omega_na_ci_low: float | None = None
+    """Lower 95% bootstrap CI for ``omega_na``."""
+    omega_na_ci_high: float | None = None
+    """Upper 95% bootstrap CI for ``omega_na``."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation."""
@@ -93,6 +105,21 @@ class AlphaTGResult:
                 f"  omega:         {self.omega:.4f} "
                 f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
             )
+            if self.omega_ci_low is not None and self.omega_ci_high is not None:
+                lines.append(
+                    f"    omega 95% CI:    ({self.omega_ci_low:.4f}, "
+                    f"{self.omega_ci_high:.4f})"
+                )
+            if self.omega_a_ci_low is not None and self.omega_a_ci_high is not None:
+                lines.append(
+                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, "
+                    f"{self.omega_a_ci_high:.4f})"
+                )
+            if self.omega_na_ci_low is not None and self.omega_na_ci_high is not None:
+                lines.append(
+                    f"    omega_na 95% CI: ({self.omega_na_ci_low:.4f}, "
+                    f"{self.omega_na_ci_high:.4f})"
+                )
         return "\n".join(lines)
 
     def to_dict(self) -> dict:
@@ -112,6 +139,12 @@ class AlphaTGResult:
             "omega": self.omega,
             "omega_a": self.omega_a,
             "omega_na": self.omega_na,
+            "omega_ci_low": self.omega_ci_low,
+            "omega_ci_high": self.omega_ci_high,
+            "omega_a_ci_low": self.omega_a_ci_low,
+            "omega_a_ci_high": self.omega_a_ci_high,
+            "omega_na_ci_low": self.omega_na_ci_low,
+            "omega_na_ci_high": self.omega_na_ci_high,
         }
 
 
@@ -197,26 +230,54 @@ def alpha_tg_from_gene_data(
 
     alpha_tg = 1.0 - ni_tg
 
-    # Bootstrap for confidence intervals
+    # Bootstrap for confidence intervals; resamples genes, so Dn/Ds/Ln/Ls
+    # totals also vary per replicate, giving omega its own sampling distribution.
     rng = np.random.default_rng(seed)
     bootstrap_alphas: list[float] = []
+    # omega_decomposition returns all three or none, so these stay in lockstep.
+    bootstrap_omegas: list[float] = []
+    bootstrap_omega_a: list[float] = []
+    bootstrap_omega_na: list[float] = []
 
     for _ in range(bootstrap_replicates):
-        # Resample genes with replacement
         indices = rng.integers(0, num_genes, size=num_genes)
         boot_data = [gene_data[i] for i in indices]
 
         boot_ni = compute_ni_tg(boot_data)
-        if boot_ni is not None:
-            bootstrap_alphas.append(1.0 - boot_ni)
+        if boot_ni is None:
+            continue
+        boot_alpha = 1.0 - boot_ni
+        bootstrap_alphas.append(boot_alpha)
 
-    # Calculate 95% CI
+        boot_dn = sum(g.dn for g in boot_data)
+        boot_ds = sum(g.ds for g in boot_data)
+        boot_ln, boot_ls = sum_site_totals(boot_data)
+        boot_omega, boot_oa, boot_ona = omega_decomposition(
+            boot_dn, boot_ds, boot_ln, boot_ls, boot_alpha
+        )
+        if boot_omega is not None:
+            bootstrap_omegas.append(boot_omega)
+            bootstrap_omega_a.append(boot_oa)
+            bootstrap_omega_na.append(boot_ona)
+
     if bootstrap_alphas:
-        ci_low = float(np.percentile(bootstrap_alphas, 2.5))
-        ci_high = float(np.percentile(bootstrap_alphas, 97.5))
+        ci_low, ci_high = np.percentile(bootstrap_alphas, [2.5, 97.5])
+        ci_low, ci_high = float(ci_low), float(ci_high)
     else:
-        ci_low = alpha_tg
-        ci_high = alpha_tg
+        ci_low = ci_high = alpha_tg
+
+    if bootstrap_omegas:
+        cis = np.percentile(
+            [bootstrap_omegas, bootstrap_omega_a, bootstrap_omega_na],
+            [2.5, 97.5],
+            axis=1,
+        )
+        omega_ci_low, omega_a_ci_low, omega_na_ci_low = (float(x) for x in cis[0])
+        omega_ci_high, omega_a_ci_high, omega_na_ci_high = (float(x) for x in cis[1])
+    else:
+        omega_ci_low = omega_ci_high = None
+        omega_a_ci_low = omega_a_ci_high = None
+        omega_na_ci_low = omega_na_ci_high = None
 
     omega, omega_a, omega_na = omega_decomposition(
         dn_total, ds_total, ln_total, ls_total, alpha_tg
@@ -237,4 +298,10 @@ def alpha_tg_from_gene_data(
         omega=omega,
         omega_a=omega_a,
         omega_na=omega_na,
+        omega_ci_low=omega_ci_low,
+        omega_ci_high=omega_ci_high,
+        omega_a_ci_low=omega_a_ci_low,
+        omega_a_ci_high=omega_a_ci_high,
+        omega_na_ci_low=omega_na_ci_low,
+        omega_na_ci_high=omega_na_ci_high,
     )

--- a/src/mkado/analysis/alpha_tg.py
+++ b/src/mkado/analysis/alpha_tg.py
@@ -22,7 +22,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from mkado.analysis.asymptotic import PolymorphismData
+from mkado.analysis.asymptotic import PolymorphismData, sum_site_totals
+from mkado.analysis.statistics import omega_decomposition
 
 
 @dataclass
@@ -62,6 +63,17 @@ class AlphaTGResult:
     ps_total: int
     """Total synonymous polymorphism across all genes."""
 
+    ln: float | None = None
+    """Total non-synonymous sites (Nei-Gojobori) summed across genes."""
+    ls: float | None = None
+    """Total synonymous sites (Nei-Gojobori) summed across genes."""
+    omega: float | None = None
+    """``(Dn_total/Ds_total) * (Ls/Ln)`` — pooled dN/dS."""
+    omega_a: float | None = None
+    """Adaptive rate ``alpha_tg * omega`` (Gossmann, Keightley & Eyre-Walker 2012)."""
+    omega_na: float | None = None
+    """Non-adaptive component ``(1 - alpha_tg) * omega``."""
+
     def __str__(self) -> str:
         """Return a human-readable string representation."""
         lines = [
@@ -72,6 +84,15 @@ class AlphaTGResult:
             f"  Polymorphism:  Pn={self.pn_total}, Ps={self.ps_total}",
             f"  Genes: {self.num_genes}",
         ]
+        if self.ln is not None and self.ls is not None:
+            lines.append(f"  Sites:         Ln={self.ln:.2f}, Ls={self.ls:.2f}")
+        if self.omega is not None:
+            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
+            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
+            lines.append(
+                f"  omega:         {self.omega:.4f} "
+                f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
+            )
         return "\n".join(lines)
 
     def to_dict(self) -> dict:
@@ -86,6 +107,11 @@ class AlphaTGResult:
             "ds_total": self.ds_total,
             "pn_total": self.pn_total,
             "ps_total": self.ps_total,
+            "ln": self.ln,
+            "ls": self.ls,
+            "omega": self.omega,
+            "omega_a": self.omega_a,
+            "omega_na": self.omega_na,
         }
 
 
@@ -148,6 +174,8 @@ def alpha_tg_from_gene_data(
     )
     num_genes = len(gene_data)
 
+    ln_total, ls_total = sum_site_totals(gene_data)
+
     # Compute point estimate
     ni_tg = compute_ni_tg(gene_data)
 
@@ -163,6 +191,8 @@ def alpha_tg_from_gene_data(
             ds_total=ds_total,
             pn_total=pn_total,
             ps_total=ps_total,
+            ln=ln_total,
+            ls=ls_total,
         )
 
     alpha_tg = 1.0 - ni_tg
@@ -188,6 +218,10 @@ def alpha_tg_from_gene_data(
         ci_low = alpha_tg
         ci_high = alpha_tg
 
+    omega, omega_a, omega_na = omega_decomposition(
+        dn_total, ds_total, ln_total, ls_total, alpha_tg
+    )
+
     return AlphaTGResult(
         alpha_tg=alpha_tg,
         ni_tg=ni_tg,
@@ -198,4 +232,9 @@ def alpha_tg_from_gene_data(
         ds_total=ds_total,
         pn_total=pn_total,
         ps_total=ps_total,
+        ln=ln_total,
+        ls=ls_total,
+        omega=omega,
+        omega_a=omega_a,
+        omega_na=omega_na,
     )

--- a/src/mkado/analysis/alpha_tg.py
+++ b/src/mkado/analysis/alpha_tg.py
@@ -107,13 +107,11 @@ class AlphaTGResult:
             )
             if self.omega_ci_low is not None and self.omega_ci_high is not None:
                 lines.append(
-                    f"    omega 95% CI:    ({self.omega_ci_low:.4f}, "
-                    f"{self.omega_ci_high:.4f})"
+                    f"    omega 95% CI:    ({self.omega_ci_low:.4f}, {self.omega_ci_high:.4f})"
                 )
             if self.omega_a_ci_low is not None and self.omega_a_ci_high is not None:
                 lines.append(
-                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, "
-                    f"{self.omega_a_ci_high:.4f})"
+                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, {self.omega_a_ci_high:.4f})"
                 )
             if self.omega_na_ci_low is not None and self.omega_na_ci_high is not None:
                 lines.append(
@@ -199,12 +197,8 @@ def alpha_tg_from_gene_data(
     # Calculate totals
     dn_total = sum(g.dn for g in gene_data)
     ds_total = sum(g.ds for g in gene_data)
-    pn_total = sum(
-        sum(1 for _, ptype in g.polymorphisms if ptype == "N") for g in gene_data
-    )
-    ps_total = sum(
-        sum(1 for _, ptype in g.polymorphisms if ptype == "S") for g in gene_data
-    )
+    pn_total = sum(sum(1 for _, ptype in g.polymorphisms if ptype == "N") for g in gene_data)
+    ps_total = sum(sum(1 for _, ptype in g.polymorphisms if ptype == "S") for g in gene_data)
     num_genes = len(gene_data)
 
     ln_total, ls_total = sum_site_totals(gene_data)
@@ -279,9 +273,7 @@ def alpha_tg_from_gene_data(
         omega_a_ci_low = omega_a_ci_high = None
         omega_na_ci_low = omega_na_ci_high = None
 
-    omega, omega_a, omega_na = omega_decomposition(
-        dn_total, ds_total, ln_total, ls_total, alpha_tg
-    )
+    omega, omega_a, omega_na = omega_decomposition(dn_total, ds_total, ln_total, ls_total, alpha_tg)
 
     return AlphaTGResult(
         alpha_tg=alpha_tg,

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -125,6 +125,41 @@ class AsymptoticMKResult:
     omega_na: float | None = None
     """Non-adaptive component ``(1 - alpha_asymptotic) * omega``."""
 
+    # Dn, Ds, Ln, Ls are constants under the asymptotic Monte Carlo procedure,
+    # so omega has no sampling distribution. The CIs on omega_a and omega_na
+    # are pure arithmetic transforms of the existing alpha CI: no need to
+    # store them.
+    @property
+    def omega_a_ci_low(self) -> float | None:
+        """Lower 95% CI for ``omega_a`` = ``ci_low * omega``."""
+        if self.omega is None:
+            return None
+        return self.ci_low * self.omega
+
+    @property
+    def omega_a_ci_high(self) -> float | None:
+        """Upper 95% CI for ``omega_a`` = ``ci_high * omega``."""
+        if self.omega is None:
+            return None
+        return self.ci_high * self.omega
+
+    @property
+    def omega_na_ci_low(self) -> float | None:
+        """Lower 95% CI for ``omega_na`` = ``(1 - ci_high) * omega``.
+
+        Percentiles flip because ``(1 - alpha)`` is monotonically decreasing.
+        """
+        if self.omega is None:
+            return None
+        return (1.0 - self.ci_high) * self.omega
+
+    @property
+    def omega_na_ci_high(self) -> float | None:
+        """Upper 95% CI for ``omega_na`` = ``(1 - ci_low) * omega``."""
+        if self.omega is None:
+            return None
+        return (1.0 - self.ci_low) * self.omega
+
     def __str__(self) -> str:
         lines = [
             "Asymptotic MK Test Results:",
@@ -143,6 +178,16 @@ class AsymptoticMKResult:
                 f"  omega: {self.omega:.4f} "
                 f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
             )
+            if self.omega_a_ci_low is not None and self.omega_a_ci_high is not None:
+                lines.append(
+                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, "
+                    f"{self.omega_a_ci_high:.4f})"
+                )
+            if self.omega_na_ci_low is not None and self.omega_na_ci_high is not None:
+                lines.append(
+                    f"    omega_na 95% CI: ({self.omega_na_ci_low:.4f}, "
+                    f"{self.omega_na_ci_high:.4f})"
+                )
         if self.num_genes > 0:
             lines.append(f"  Genes aggregated: {self.num_genes}")
         if self.model_type == "exponential":
@@ -186,6 +231,10 @@ class AsymptoticMKResult:
         result["omega"] = self.omega
         result["omega_a"] = self.omega_a
         result["omega_na"] = self.omega_na
+        result["omega_a_ci_low"] = self.omega_a_ci_low
+        result["omega_a_ci_high"] = self.omega_a_ci_high
+        result["omega_na_ci_low"] = self.omega_na_ci_low
+        result["omega_na_ci_high"] = self.omega_na_ci_high
         return result
 
 
@@ -194,7 +243,7 @@ def _attach_omega(
     ln: float | None,
     ls: float | None,
 ) -> AsymptoticMKResult:
-    """Populate ln/ls/omega fields on an asymptotic result in-place."""
+    """Populate ln/ls/omega point estimates on an asymptotic result in-place."""
     omega, omega_a, omega_na = omega_decomposition(
         result.dn, result.ds, ln, ls, result.alpha_asymptotic
     )

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Callable
 import numpy as np
 from scipy import optimize
 
+from mkado.analysis.statistics import omega_decomposition
 from mkado.core.alignment import AlignedPair
 from mkado.core.codons import DEFAULT_CODE, GeneticCode
 from mkado.core.sequences import SequenceSet
@@ -32,6 +33,22 @@ class PolymorphismData:
     dn: int = 0
     ds: int = 0
     gene_id: str = ""
+    ln: float | None = None
+    """Total non-synonymous sites (Nei-Gojobori) over analyzed codons."""
+    ls: float | None = None
+    """Total synonymous sites (Nei-Gojobori) over analyzed codons."""
+
+
+def sum_site_totals(
+    gene_data: list[PolymorphismData],
+) -> tuple[float | None, float | None]:
+    """Sum per-gene Nei-Gojobori (Ln, Ls); return ``(None, None)`` if any gene lacks them."""
+    if not gene_data or any(g.ln is None or g.ls is None for g in gene_data):
+        return (None, None)
+    return (
+        sum(g.ln for g in gene_data),  # type: ignore[misc]
+        sum(g.ls for g in gene_data),  # type: ignore[misc]
+    )
 
 
 @dataclass
@@ -46,6 +63,10 @@ class AggregatedSFS:
     dn_total: int = 0
     ds_total: int = 0
     num_genes: int = 0
+    ln_total: float | None = None
+    """Sum of per-gene Nei-Gojobori non-synonymous sites."""
+    ls_total: float | None = None
+    """Sum of per-gene Nei-Gojobori synonymous sites."""
 
 
 @dataclass
@@ -93,6 +114,16 @@ class AsymptoticMKResult:
     """Total non-synonymous polymorphisms (sum across all SFS bins)."""
     ps_total: int = 0
     """Total synonymous polymorphisms (sum across all SFS bins)."""
+    ln: float | None = None
+    """Total non-synonymous sites (Nei-Gojobori)."""
+    ls: float | None = None
+    """Total synonymous sites (Nei-Gojobori)."""
+    omega: float | None = None
+    """``(Dn/Ds) * (Ls/Ln)`` — dN/dS ratio."""
+    omega_a: float | None = None
+    """Adaptive component ``alpha_asymptotic * omega``."""
+    omega_na: float | None = None
+    """Non-adaptive component ``(1 - alpha_asymptotic) * omega``."""
 
     def __str__(self) -> str:
         lines = [
@@ -103,6 +134,15 @@ class AsymptoticMKResult:
         ]
         if self.pn_total > 0 or self.ps_total > 0:
             lines.append(f"  Polymorphism: Pn={self.pn_total}, Ps={self.ps_total}")
+        if self.ln is not None and self.ls is not None:
+            lines.append(f"  Sites: Ln={self.ln:.2f}, Ls={self.ls:.2f}")
+        if self.omega is not None:
+            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
+            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
+            lines.append(
+                f"  omega: {self.omega:.4f} "
+                f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
+            )
         if self.num_genes > 0:
             lines.append(f"  Genes aggregated: {self.num_genes}")
         if self.model_type == "exponential":
@@ -141,7 +181,29 @@ class AsymptoticMKResult:
         if self.pn_total > 0 or self.ps_total > 0:
             result["pn_total"] = self.pn_total
             result["ps_total"] = self.ps_total
+        result["ln"] = self.ln
+        result["ls"] = self.ls
+        result["omega"] = self.omega
+        result["omega_a"] = self.omega_a
+        result["omega_na"] = self.omega_na
         return result
+
+
+def _attach_omega(
+    result: AsymptoticMKResult,
+    ln: float | None,
+    ls: float | None,
+) -> AsymptoticMKResult:
+    """Populate ln/ls/omega fields on an asymptotic result in-place."""
+    omega, omega_a, omega_na = omega_decomposition(
+        result.dn, result.ds, ln, ls, result.alpha_asymptotic
+    )
+    result.ln = ln
+    result.ls = ls
+    result.omega = omega
+    result.omega_a = omega_a
+    result.omega_na = omega_na
+    return result
 
 
 def _exponential_model(x: np.ndarray, a: float, b: float, c: float) -> np.ndarray:
@@ -329,11 +391,15 @@ def extract_polymorphism_data(
             for _ in range(syn):
                 poly_data.append((derived_freq, "S"))
 
+    ln, ls = pair.count_total_sites()
+
     return PolymorphismData(
         polymorphisms=poly_data,
         dn=dn,
         ds=ds,
         gene_id=gene_id,
+        ln=ln,
+        ls=ls,
     )
 
 
@@ -353,6 +419,7 @@ def aggregate_polymorphism_data(
     # Sum divergence across all genes
     dn_total = sum(g.dn for g in gene_data)
     ds_total = sum(g.ds for g in gene_data)
+    ln_total, ls_total = sum_site_totals(gene_data)
 
     # Combine all polymorphisms
     all_polymorphisms: list[tuple[float, str]] = []
@@ -383,6 +450,8 @@ def aggregate_polymorphism_data(
         dn_total=dn_total,
         ds_total=ds_total,
         num_genes=len(gene_data),
+        ln_total=ln_total,
+        ls_total=ls_total,
     )
 
 
@@ -440,7 +509,7 @@ def asymptotic_mk_test_aggregated(
         if ds > 0 and dn > 0 and ps_total > 0:
             simple_alpha = 1.0 - (ds * pn_total) / (dn * ps_total)
 
-        return AsymptoticMKResult(
+        result = AsymptoticMKResult(
             frequency_bins=list(bin_centers),
             alpha_by_freq=alpha_values,
             alpha_x_values=valid_centers,
@@ -453,6 +522,7 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
         )
+        return _attach_omega(result, agg.ln_total, agg.ls_total)
 
     x_data = np.array(valid_centers)
     y_data = np.array(alpha_values)
@@ -563,7 +633,7 @@ def asymptotic_mk_test_aggregated(
         use_exponential = False
     else:
         # Both failed, use last value
-        return AsymptoticMKResult(
+        result = AsymptoticMKResult(
             frequency_bins=list(bin_centers),
             alpha_by_freq=alpha_values,
             alpha_x_values=valid_centers,
@@ -576,10 +646,11 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
         )
+        return _attach_omega(result, agg.ln_total, agg.ls_total)
 
     if use_exponential:
         a, b, c = exp_popt
-        return AsymptoticMKResult(
+        result = AsymptoticMKResult(
             frequency_bins=list(bin_centers),
             alpha_by_freq=alpha_values,
             alpha_x_values=valid_centers,
@@ -598,7 +669,7 @@ def asymptotic_mk_test_aggregated(
         )
     else:
         a_lin, b_lin = lin_popt
-        return AsymptoticMKResult(
+        result = AsymptoticMKResult(
             frequency_bins=list(bin_centers),
             alpha_by_freq=alpha_values,
             alpha_x_values=valid_centers,
@@ -615,6 +686,7 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
         )
+    return _attach_omega(result, agg.ln_total, agg.ls_total)
 
 
 def asymptotic_mk_test(
@@ -659,6 +731,7 @@ def asymptotic_mk_test(
 
     # Create aligned pair
     pair = AlignedPair(ingroup=ingroup, outgroup=outgroup, genetic_code=code)
+    ln_total, ls_total = pair.count_total_sites()
 
     # Count divergence
     dn = 0
@@ -763,7 +836,7 @@ def asymptotic_mk_test(
             if total_ps > 0:
                 simple_alpha = 1.0 - (ds * total_pn) / (dn * total_ps)
 
-        return AsymptoticMKResult(
+        result = AsymptoticMKResult(
             frequency_bins=list(bin_centers),
             alpha_by_freq=alpha_values,
             alpha_x_values=valid_centers,
@@ -773,6 +846,7 @@ def asymptotic_mk_test(
             dn=dn,
             ds=ds,
         )
+        return _attach_omega(result, ln_total, ls_total)
 
     # Fit exponential model: α(x) = a + b * exp(-c * x)
     x_data = np.array(valid_centers)
@@ -866,7 +940,7 @@ def asymptotic_mk_test(
         ci_low = alpha_asymp
         ci_high = alpha_asymp
 
-    return AsymptoticMKResult(
+    result = AsymptoticMKResult(
         frequency_bins=list(bin_centers),
         alpha_by_freq=alpha_values,
         alpha_x_values=valid_centers,
@@ -879,3 +953,4 @@ def asymptotic_mk_test(
         dn=dn,
         ds=ds,
     )
+    return _attach_omega(result, ln_total, ls_total)

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -175,13 +175,11 @@ class AsymptoticMKResult:
             omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
             omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
             lines.append(
-                f"  omega: {self.omega:.4f} "
-                f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
+                f"  omega: {self.omega:.4f} (omega_a={omega_a_str}, omega_na={omega_na_str})"
             )
             if self.omega_a_ci_low is not None and self.omega_a_ci_high is not None:
                 lines.append(
-                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, "
-                    f"{self.omega_a_ci_high:.4f})"
+                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, {self.omega_a_ci_high:.4f})"
                 )
             if self.omega_na_ci_low is not None and self.omega_na_ci_high is not None:
                 lines.append(
@@ -197,8 +195,7 @@ class AsymptoticMKResult:
             )
         else:
             lines.append(
-                f"  Fit ({self.model_type}): α(x) = {self.fit_a:.4f} + "
-                f"{self.fit_b:.4f} * x"
+                f"  Fit ({self.model_type}): α(x) = {self.fit_a:.4f} + {self.fit_b:.4f} * x"
             )
         return "\n".join(lines)
 

--- a/src/mkado/analysis/imputed.py
+++ b/src/mkado/analysis/imputed.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from mkado.analysis.asymptotic import PolymorphismData
-from mkado.analysis.statistics import fishers_exact
+from mkado.analysis.asymptotic import PolymorphismData, sum_site_totals
+from mkado.analysis.statistics import fishers_exact, omega_decomposition
 
 
 @dataclass
@@ -57,6 +57,16 @@ class ImputedMKResult:
     """Estimated DFE neutral fraction."""
     cutoff: float = 0.15
     """Derived allele frequency below which polymorphisms are treated as the imputation pool."""
+    ln: float | None = None
+    """Total non-synonymous sites (Nei-Gojobori) over analyzed codons."""
+    ls: float | None = None
+    """Total synonymous sites (Nei-Gojobori) over analyzed codons."""
+    omega: float | None = None
+    """``(Dn/Ds) * (Ls/Ln)`` — dN/dS ratio."""
+    omega_a: float | None = None
+    """Adaptive rate ``alpha * omega`` with imputed alpha (Gossmann, Keightley & Eyre-Walker 2012)."""
+    omega_na: float | None = None
+    """Non-adaptive component ``(1 - alpha) * omega``."""
 
     def __str__(self) -> str:
         alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "N/A"
@@ -70,6 +80,15 @@ class ImputedMKResult:
             f"  Alpha (α):     {alpha_str}",
             f"  p-value:       {self.p_value:.4g}",
         ]
+        if self.ln is not None and self.ls is not None:
+            lines.append(f"  Sites:         Ln={self.ln:.2f}, Ls={self.ls:.2f}")
+        if self.omega is not None:
+            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
+            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
+            lines.append(
+                f"  omega:         {self.omega:.4f} "
+                f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
+            )
         if self.d is not None:
             lines.append(f"  DFE fractions: d={self.d:.4f}, b={self.b:.4f}, f={self.f:.4f}")
         return "\n".join(lines)
@@ -86,6 +105,11 @@ class ImputedMKResult:
             "pn_total": self.pn_total,
             "ps_total": self.ps_total,
             "cutoff": self.cutoff,
+            "ln": self.ln,
+            "ls": self.ls,
+            "omega": self.omega,
+            "omega_a": self.omega_a,
+            "omega_na": self.omega_na,
         }
         if self.d is not None:
             result["d"] = self.d
@@ -148,6 +172,12 @@ def _compute_imputed(
             f_frac = (m0 * pn_neutral) / (mi * ps_total)
             d_frac = 1.0 - f_frac - b_frac
 
+    # ``num_*_sites`` are aliases for Ls (m0) and Ln (mi) — the DFE inputs
+    # double as Nei-Gojobori site totals for the omega decomposition.
+    omega, omega_a, omega_na = omega_decomposition(
+        dn, ds, num_nonsynonymous_sites, num_synonymous_sites, alpha_val
+    )
+
     return ImputedMKResult(
         alpha=alpha_val,
         p_value=p_value,
@@ -161,6 +191,11 @@ def _compute_imputed(
         b=b_frac,
         f=f_frac,
         cutoff=cutoff,
+        ln=num_nonsynonymous_sites,
+        ls=num_synonymous_sites,
+        omega=omega,
+        omega_a=omega_a,
+        omega_na=omega_na,
     )
 
 
@@ -188,13 +223,15 @@ def imputed_mk_test(
     Returns:
         ImputedMKResult with corrected alpha and optionally DFE fractions
     """
+    ls = num_synonymous_sites if num_synonymous_sites is not None else gene_data.ls
+    ln = num_nonsynonymous_sites if num_nonsynonymous_sites is not None else gene_data.ln
     return _compute_imputed(
         gene_data.polymorphisms,
         gene_data.dn,
         gene_data.ds,
         cutoff,
-        num_synonymous_sites,
-        num_nonsynonymous_sites,
+        ls,
+        ln,
     )
 
 
@@ -227,11 +264,15 @@ def imputed_mk_test_multi(
         dn_total += g.dn
         ds_total += g.ds
 
+    ln_agg, ls_agg = sum_site_totals(gene_data)
+    ls = num_synonymous_sites if num_synonymous_sites is not None else ls_agg
+    ln = num_nonsynonymous_sites if num_nonsynonymous_sites is not None else ln_agg
+
     return _compute_imputed(
         all_polymorphisms,
         dn_total,
         ds_total,
         cutoff,
-        num_synonymous_sites,
-        num_nonsynonymous_sites,
+        ls,
+        ln,
     )

--- a/src/mkado/analysis/mk_test.py
+++ b/src/mkado/analysis/mk_test.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from mkado.analysis.statistics import alpha, dos, fishers_exact, neutrality_index
+from mkado.analysis.statistics import (
+    alpha,
+    dos,
+    fishers_exact,
+    neutrality_index,
+    omega_decomposition,
+)
 from mkado.core.alignment import AlignedPair
 from mkado.core.codons import DEFAULT_CODE, GeneticCode
 from mkado.core.sequences import SequenceSet
@@ -48,19 +54,35 @@ class MKResult:
     """Proportion of adaptive substitutions ``1 - NI``."""
     dos: float | None
     """Direction of Selection ``Dn/(Dn+Ds) - Pn/(Pn+Ps)`` (Stoletzki & Eyre-Walker 2011)."""
+    ln: float | None = None
+    """Total non-synonymous sites (Nei-Gojobori) over analyzed codons."""
+    ls: float | None = None
+    """Total synonymous sites (Nei-Gojobori) over analyzed codons."""
+    omega: float | None = None
+    """``(Dn/Ds) * (Ls/Ln)`` — dN/dS ratio. ``None`` when undefined.
+
+    Note: this result class deliberately omits ``omega_a`` / ``omega_na``;
+    the per-gene Smith & Eyre-Walker alpha is too noisy to give a useful
+    rate decomposition. See ``docs/omega.rst`` for the rationale.
+    """
 
     def __str__(self) -> str:
         ni_str = f"{self.ni:.4f}" if self.ni is not None else "N/A"
         alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "N/A"
         dos_str = f"{self.dos:.4f}" if self.dos is not None else "N/A"
+        omega_str = f"{self.omega:.4f}" if self.omega is not None else "N/A"
+        ls_str = f"{self.ls:.2f}" if self.ls is not None else "N/A"
+        ln_str = f"{self.ln:.2f}" if self.ln is not None else "N/A"
         return (
             f"MK Test Results:\n"
             f"  Divergence:    Dn={self.dn}, Ds={self.ds}\n"
             f"  Polymorphism:  Pn={self.pn}, Ps={self.ps}\n"
+            f"  Sites:         Ln={ln_str}, Ls={ls_str}\n"
             f"  Fisher's exact p-value: {self.p_value:.4g}\n"
             f"  Neutrality Index (NI):  {ni_str}\n"
             f"  Alpha (α):              {alpha_str}\n"
-            f"  DoS:                    {dos_str}"
+            f"  DoS:                    {dos_str}\n"
+            f"  omega (dN/dS):          {omega_str}"
         )
 
     def to_dict(self) -> dict:
@@ -74,6 +96,9 @@ class MKResult:
             "ni": self.ni,
             "alpha": self.alpha,
             "dos": self.dos,
+            "ln": self.ln,
+            "ls": self.ls,
+            "omega": self.omega,
         }
 
 
@@ -195,6 +220,8 @@ def mk_test(
     ni = neutrality_index(dn, ds, pn, ps)
     a = alpha(dn, ds, pn, ps)
     d = dos(dn, ds, pn, ps)
+    ln, ls = pair.count_total_sites()
+    omega, _, _ = omega_decomposition(dn, ds, ln, ls, a)
 
     return MKResult(
         dn=dn,
@@ -205,11 +232,19 @@ def mk_test(
         ni=ni,
         alpha=a,
         dos=d,
+        ln=ln,
+        ls=ls,
+        omega=omega,
     )
 
 
 def mk_test_from_counts(
-    dn: int, ds: int, pn: int, ps: int
+    dn: int,
+    ds: int,
+    pn: int,
+    ps: int,
+    ln: float | None = None,
+    ls: float | None = None,
 ) -> MKResult:
     """Create MK test results from pre-computed counts.
 
@@ -220,6 +255,8 @@ def mk_test_from_counts(
         ds: Synonymous divergence
         pn: Non-synonymous polymorphisms
         ps: Synonymous polymorphisms
+        ln: Total non-synonymous sites (optional, enables omega computation)
+        ls: Total synonymous sites (optional, enables omega computation)
 
     Returns:
         MKResult with calculated statistics
@@ -228,6 +265,7 @@ def mk_test_from_counts(
     ni = neutrality_index(dn, ds, pn, ps)
     a = alpha(dn, ds, pn, ps)
     d = dos(dn, ds, pn, ps)
+    omega, _, _ = omega_decomposition(dn, ds, ln, ls, a)
 
     return MKResult(
         dn=dn,
@@ -238,4 +276,7 @@ def mk_test_from_counts(
         ni=ni,
         alpha=a,
         dos=d,
+        ln=ln,
+        ls=ls,
+        omega=omega,
     )

--- a/src/mkado/analysis/polarized.py
+++ b/src/mkado/analysis/polarized.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from mkado.analysis.statistics import alpha, dos, fishers_exact, neutrality_index
+from mkado.analysis.statistics import (
+    alpha,
+    dos,
+    fishers_exact,
+    neutrality_index,
+    omega_decomposition,
+)
 from mkado.core.alignment import PolarizedAlignedPair
 from mkado.core.codons import DEFAULT_CODE, GeneticCode
 from mkado.core.sequences import SequenceSet
@@ -61,11 +67,25 @@ class PolarizedMKResult:
     """Proportion of adaptive substitutions on the ingroup lineage."""
     dos_ingroup: float | None
     """Direction of Selection for the ingroup lineage."""
+    ln: float | None = None
+    """Total non-synonymous sites (Nei-Gojobori) over analyzed codons."""
+    ls: float | None = None
+    """Total synonymous sites (Nei-Gojobori) over analyzed codons."""
+    omega: float | None = None
+    """``(Dn_ingroup/Ds_ingroup) * (Ls/Ln)`` — ingroup-lineage dN/dS.
+
+    Note: this result class deliberately omits ``omega_a`` / ``omega_na``;
+    per-gene polarized alpha is too noisy to give a useful rate
+    decomposition. See ``docs/omega.rst`` for the rationale.
+    """
 
     def __str__(self) -> str:
         ni_str = f"{self.ni_ingroup:.4f}" if self.ni_ingroup is not None else "N/A"
         alpha_str = f"{self.alpha_ingroup:.4f}" if self.alpha_ingroup is not None else "N/A"
         dos_str = f"{self.dos_ingroup:.4f}" if self.dos_ingroup is not None else "N/A"
+        omega_str = f"{self.omega:.4f}" if self.omega is not None else "N/A"
+        ls_str = f"{self.ls:.2f}" if self.ls is not None else "N/A"
+        ln_str = f"{self.ln:.2f}" if self.ln is not None else "N/A"
         return (
             f"Polarized MK Test Results:\n"
             f"  Ingroup Lineage:\n"
@@ -73,6 +93,8 @@ class PolarizedMKResult:
             f"    Polymorphism:  Pn={self.pn_ingroup}, Ps={self.ps_ingroup}\n"
             f"    Fisher's p-value: {self.p_value_ingroup:.4g}\n"
             f"    NI: {ni_str}, Alpha: {alpha_str}, DoS: {dos_str}\n"
+            f"    omega (dN/dS): {omega_str}\n"
+            f"  Sites: Ln={ln_str}, Ls={ls_str}\n"
             f"  Outgroup Lineage:\n"
             f"    Divergence:    Dn={self.dn_outgroup}, Ds={self.ds_outgroup}\n"
             f"  Unpolarized:\n"
@@ -92,6 +114,7 @@ class PolarizedMKResult:
                 "ni": self.ni_ingroup,
                 "alpha": self.alpha_ingroup,
                 "dos": self.dos_ingroup,
+                "omega": self.omega,
             },
             "outgroup": {
                 "dn": self.dn_outgroup,
@@ -103,6 +126,8 @@ class PolarizedMKResult:
                 "pn": self.pn_unpolarized,
                 "ps": self.ps_unpolarized,
             },
+            "ln": self.ln,
+            "ls": self.ls,
         }
 
 
@@ -257,6 +282,8 @@ def polarized_mk_test(
     ni = neutrality_index(dn_in, ds_in, pn_in, ps_in)
     a = alpha(dn_in, ds_in, pn_in, ps_in)
     d = dos(dn_in, ds_in, pn_in, ps_in)
+    ln, ls = pair.count_total_sites()
+    omega, _, _ = omega_decomposition(dn_in, ds_in, ln, ls, a)
 
     return PolarizedMKResult(
         dn_ingroup=dn_in,
@@ -273,4 +300,7 @@ def polarized_mk_test(
         ni_ingroup=ni,
         alpha_ingroup=a,
         dos_ingroup=d,
+        ln=ln,
+        ls=ls,
+        omega=omega,
     )

--- a/src/mkado/analysis/statistics.py
+++ b/src/mkado/analysis/statistics.py
@@ -154,6 +154,36 @@ def g_test(dn: int, ds: int, pn: int, ps: int) -> float:
     return float(p_value)
 
 
+def omega_decomposition(
+    dn: int,
+    ds: int,
+    ln: float | None,
+    ls: float | None,
+    alpha_value: float | None,
+) -> tuple[float | None, float | None, float | None]:
+    """Compute omega and its adaptive/non-adaptive decomposition.
+
+    Following Gossmann, Keightley & Eyre-Walker (2012, *Genome Biol Evol*
+    4(5):658-667), the nonsynonymous substitution rate decomposes into an
+    adaptive component ``omega_a`` and a non-adaptive component ``omega_na``::
+
+        omega    = (Dn / Ds) * (Ls / Ln)   (= dN/dS using N-G site counts)
+        omega_a  = alpha * omega
+        omega_na = (1 - alpha) * omega = omega - omega_a
+
+    Returns ``(None, None, None)`` if site counts are missing or any
+    denominator is zero. ``omega_a`` and ``omega_na`` are ``None``
+    when ``alpha_value`` is ``None``.
+    """
+    if ln is None or ls is None or ln <= 0 or ls <= 0 or ds == 0:
+        return (None, None, None)
+
+    omega = (dn * ls) / (ds * ln)
+    if alpha_value is None:
+        return (omega, None, None)
+    return (omega, alpha_value * omega, (1.0 - alpha_value) * omega)
+
+
 def confidence_interval_alpha(
     dn: int, ds: int, pn: int, ps: int, confidence: float = 0.95
 ) -> tuple[float, float] | None:

--- a/src/mkado/analysis/statistics.py
+++ b/src/mkado/analysis/statistics.py
@@ -163,9 +163,9 @@ def omega_decomposition(
 ) -> tuple[float | None, float | None, float | None]:
     """Compute omega and its adaptive/non-adaptive decomposition.
 
-    Following Gossmann, Keightley & Eyre-Walker (2012, *Genome Biol Evol*
-    4(5):658-667), the nonsynonymous substitution rate decomposes into an
-    adaptive component ``omega_a`` and a non-adaptive component ``omega_na``::
+    Decomposition introduced by Gossmann, Keightley & Eyre-Walker (2012,
+    *Genome Biol Evol* 4(5):658-667) and applied to MK-style counts by
+    Coronado-Zamora et al. (2019, *Genome Biol Evol* 11(5):1463-1482)::
 
         omega    = (Dn / Ds) * (Ls / Ln)   (= dN/dS using N-G site counts)
         omega_a  = alpha * omega

--- a/src/mkado/core/alignment.py
+++ b/src/mkado/core/alignment.py
@@ -158,9 +158,7 @@ class AlignedPair:
         ln = (3.0 * used) - ls
         return (ln, ls)
 
-    def classify_fixed_difference(
-        self, codon_index: int
-    ) -> tuple[int, int] | None:
+    def classify_fixed_difference(self, codon_index: int) -> tuple[int, int] | None:
         """Classify a fixed difference as synonymous/non-synonymous.
 
         Uses the shortest mutational path to count the minimum number of
@@ -195,9 +193,7 @@ class AlignedPair:
 
         return (nonsyn, syn)
 
-    def classify_polymorphism(
-        self, codon_index: int
-    ) -> tuple[int, int] | None:
+    def classify_polymorphism(self, codon_index: int) -> tuple[int, int] | None:
         """Classify a polymorphism as synonymous/non-synonymous.
 
         Args:
@@ -246,9 +242,7 @@ class AlignedPair:
 
         return (total_nonsyn, total_syn)
 
-    def classify_polymorphism_pooled(
-        self, codon_index: int
-    ) -> tuple[int, int] | None:
+    def classify_polymorphism_pooled(self, codon_index: int) -> tuple[int, int] | None:
         """Classify a polymorphism using codons from both populations.
 
         This follows the libsequence convention of using all unique codons
@@ -318,9 +312,7 @@ class PolarizedAlignedPair(AlignedPair):
 
     outgroup2: SequenceSet | None = None
 
-    def polarize_fixed_difference(
-        self, codon_index: int
-    ) -> tuple[str, tuple[int, int]] | None:
+    def polarize_fixed_difference(self, codon_index: int) -> tuple[str, tuple[int, int]] | None:
         """Polarize a fixed difference to determine which lineage changed.
 
         Uses the second outgroup to determine the ancestral state.
@@ -373,9 +365,7 @@ class PolarizedAlignedPair(AlignedPair):
 
         return (lineage, (nonsyn, syn))
 
-    def polarize_ingroup_polymorphism(
-        self, codon_index: int
-    ) -> tuple[int, int] | None:
+    def polarize_ingroup_polymorphism(self, codon_index: int) -> tuple[int, int] | None:
         """Polarize and classify an ingroup polymorphism.
 
         Uses outgroup2 to determine if the polymorphism arose on the ingroup

--- a/src/mkado/core/alignment.py
+++ b/src/mkado/core/alignment.py
@@ -130,6 +130,34 @@ class AlignedPair:
         outgroup_poly = set(self.outgroup.polymorphic_codons())
         return sorted(ingroup_poly | outgroup_poly)
 
+    def count_total_sites(self) -> tuple[float, float]:
+        """Aggregate total non-synonymous (Ln) and synonymous (Ls) sites.
+
+        For each codon position with at least one clean codon in each group,
+        averages the Nei-Gojobori per-codon synonymous site counts within
+        each group, then averages the two group means. Sums across positions
+        and returns ``(Ln, Ls)`` with ``Ln = 3 * n_codons - Ls``.
+        """
+        n_codons = self.num_codons
+        ingroup = self.ingroup
+        outgroup = self.outgroup
+        cs = self.genetic_code.count_synonymous_sites
+
+        ls = 0.0
+        used = 0
+        for i in range(n_codons):
+            in_codons_i = ingroup.codon_set_clean(i)
+            out_codons_i = outgroup.codon_set_clean(i)
+            if not in_codons_i or not out_codons_i:
+                continue
+            in_ls = sum(cs(c) for c in in_codons_i) / len(in_codons_i)
+            out_ls = sum(cs(c) for c in out_codons_i) / len(out_codons_i)
+            ls += (in_ls + out_ls) / 2.0
+            used += 1
+
+        ln = (3.0 * used) - ls
+        return (ln, ls)
+
     def classify_fixed_difference(
         self, codon_index: int
     ) -> tuple[int, int] | None:

--- a/src/mkado/core/codons.py
+++ b/src/mkado/core/codons.py
@@ -49,6 +49,8 @@ class GeneticCode:
         else:
             self._paths = _compute_codon_paths(self.code)
 
+        self._syn_sites_cache: dict[str, float] = {}
+
     @lru_cache(maxsize=4096)
     def translate(self, codon: str) -> str:
         """Translate a codon to its amino acid.
@@ -108,11 +110,17 @@ class GeneticCode:
             Number of synonymous sites (0-3)
         """
         codon = codon.upper()
+        cached = self._syn_sites_cache.get(codon)
+        if cached is not None:
+            return cached
+
         if "N" in codon or "-" in codon:
+            self._syn_sites_cache[codon] = 0.0
             return 0.0
 
         aa = self.translate(codon)
         if aa == "*" or aa == "X":
+            self._syn_sites_cache[codon] = 0.0
             return 0.0
 
         syn_sites = 0.0
@@ -133,6 +141,7 @@ class GeneticCode:
             if total_count > 0:
                 syn_sites += syn_count / total_count
 
+        self._syn_sites_cache[codon] = syn_sites
         return syn_sites
 
     def is_synonymous_change(self, codon1: str, codon2: str) -> bool | None:

--- a/src/mkado/core/sequences.py
+++ b/src/mkado/core/sequences.py
@@ -53,6 +53,12 @@ class SequenceSet:
     sequences: list[Sequence] = field(default_factory=list)
     reading_frame: int = 1
     genetic_code: GeneticCode = field(default_factory=lambda: DEFAULT_CODE)
+    _codon_set_clean_cache: dict[int, set[str]] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
+    """Per-position memoization for ``codon_set_clean()``. Treat the SequenceSet
+    as immutable once any caching method has been called; mutating ``sequences``
+    or ``reading_frame`` afterwards will leave stale entries here."""
 
     @classmethod
     def from_fasta(
@@ -83,6 +89,14 @@ class SequenceSet:
 
     def __getitem__(self, index: int) -> Sequence:
         return self.sequences[index]
+
+    def __getstate__(self) -> dict:
+        # Drop the per-position cache when pickling — it can be re-populated
+        # cheaply in the receiver and would otherwise inflate pickle size by
+        # O(num_codons) set objects.
+        state = self.__dict__.copy()
+        state["_codon_set_clean_cache"] = {}
+        return state
 
     @property
     def num_codons(self) -> int:
@@ -116,14 +130,22 @@ class SequenceSet:
     def codon_set_clean(self, codon_index: int) -> set[str]:
         """Get unique codons at a position, excluding those with N or gaps.
 
+        Result is cached per ``codon_index`` for the lifetime of the
+        ``SequenceSet``. Callers must not mutate the returned set.
+
         Args:
             codon_index: Zero-based codon index
 
         Returns:
             Set of unique valid codon strings
         """
+        cached = self._codon_set_clean_cache.get(codon_index)
+        if cached is not None:
+            return cached
         codons = self.codon_set(codon_index)
-        return {c for c in codons if "N" not in c and "-" not in c}
+        clean = {c for c in codons if "N" not in c and "-" not in c}
+        self._codon_set_clean_cache[codon_index] = clean
+        return clean
 
     def amino_set(self, codon_index: int) -> set[str]:
         """Get the set of unique amino acids at a codon position.
@@ -261,6 +283,9 @@ class SequenceSet:
             New SequenceSet containing only matching sequences
         """
         filtered = [seq for seq in self.sequences if pattern in seq.name]
+        # The new SequenceSet starts with an empty cache: the parent's cached
+        # codon sets contain codons from sequences that aren't in the filtered
+        # subset, so reusing them would yield wrong results.
         return SequenceSet(
             sequences=filtered,
             reading_frame=self.reading_frame,

--- a/src/mkado/core/sequences.py
+++ b/src/mkado/core/sequences.py
@@ -250,9 +250,7 @@ class SequenceSet:
 
         return {codon: count / total for codon, count in counts.items()}
 
-    def derived_allele_frequency(
-        self, codon_index: int, ancestral_codon: str
-    ) -> float | None:
+    def derived_allele_frequency(self, codon_index: int, ancestral_codon: str) -> float | None:
         """Calculate the derived allele frequency at a codon position.
 
         Args:

--- a/src/mkado/io/output.py
+++ b/src/mkado/io/output.py
@@ -52,10 +52,7 @@ def _omega_a_na_ci_tsv_columns(
 
 def _omega_tsv_columns(result: MKResult | PolarizedMKResult) -> str:
     """Tab-separated ``Ln\\tLs\\tomega`` for omega-only result types (MK, polarized)."""
-    return (
-        f"{_fmt_optional(result.ln)}\t{_fmt_optional(result.ls)}\t"
-        f"{_fmt_optional(result.omega)}"
-    )
+    return f"{_fmt_optional(result.ln)}\t{_fmt_optional(result.ls)}\t{_fmt_optional(result.omega)}"
 
 
 def format_result(
@@ -84,7 +81,9 @@ def format_result(
         raise ValueError(f"Unknown format: {format}")
 
 
-def _format_tsv(result: MKResult | PolarizedMKResult | AsymptoticMKResult | AlphaTGResult | ImputedMKResult) -> str:
+def _format_tsv(
+    result: MKResult | PolarizedMKResult | AsymptoticMKResult | AlphaTGResult | ImputedMKResult,
+) -> str:
     """Format results as tab-separated values."""
     from mkado.analysis.alpha_tg import AlphaTGResult
     from mkado.analysis.asymptotic import AsymptoticMKResult

--- a/src/mkado/io/output.py
+++ b/src/mkado/io/output.py
@@ -22,6 +22,32 @@ class OutputFormat(Enum):
     JSON = "json"
 
 
+def _fmt_optional(value: float | None, precision: int = 6) -> str:
+    """Format optional float as ``"NA"`` if ``None``, else ``f"{value:.{precision}f}"``."""
+    if value is None:
+        return "NA"
+    return f"{value:.{precision}f}"
+
+
+def _omega_full_tsv_columns(
+    result: AsymptoticMKResult | ImputedMKResult | AlphaTGResult,
+) -> str:
+    """Tab-separated ``Ln\\tLs\\tomega\\tomega_a\\tomega_na`` for full-decomposition results."""
+    return (
+        f"{_fmt_optional(result.ln)}\t{_fmt_optional(result.ls)}\t"
+        f"{_fmt_optional(result.omega)}\t{_fmt_optional(result.omega_a)}\t"
+        f"{_fmt_optional(result.omega_na)}"
+    )
+
+
+def _omega_tsv_columns(result: MKResult | PolarizedMKResult) -> str:
+    """Tab-separated ``Ln\\tLs\\tomega`` for omega-only result types (MK, polarized)."""
+    return (
+        f"{_fmt_optional(result.ln)}\t{_fmt_optional(result.ls)}\t"
+        f"{_fmt_optional(result.omega)}"
+    )
+
+
 def format_result(
     result: MKResult | PolarizedMKResult | AsymptoticMKResult | AlphaTGResult | ImputedMKResult,
     format: OutputFormat = OutputFormat.PRETTY,
@@ -58,63 +84,87 @@ def _format_tsv(result: MKResult | PolarizedMKResult | AsymptoticMKResult | Alph
 
     if isinstance(result, ImputedMKResult):
         alpha_str = f"{result.alpha:.6f}" if result.alpha is not None else "NA"
-        header = "Dn\tDs\tPn\tPs\tPwd\tPn_neutral\talpha\tp_value\tcutoff"
+        header = (
+            "Dn\tDs\tPn\tPs\tPwd\tPn_neutral\talpha\tp_value\tcutoff\t"
+            "Ln\tLs\tomega\tomega_a\tomega_na"
+        )
         values = (
             f"{result.dn}\t{result.ds}\t{result.pn_total}\t{result.ps_total}\t"
             f"{result.pwd:.2f}\t{result.pn_neutral:.2f}\t{alpha_str}\t"
-            f"{result.p_value:.6g}\t{result.cutoff}"
+            f"{result.p_value:.6g}\t{result.cutoff}\t"
+            f"{_omega_full_tsv_columns(result)}"
         )
         return f"{header}\n{values}"
 
     elif isinstance(result, MKResult):
-        header = "Dn\tDs\tPn\tPs\tp_value\tNI\talpha\tDoS"
+        header = "Dn\tDs\tPn\tPs\tp_value\tNI\talpha\tDoS\tLn\tLs\tomega"
         ni_str = f"{result.ni:.6f}" if result.ni is not None else "NA"
         alpha_str = f"{result.alpha:.6f}" if result.alpha is not None else "NA"
         dos_str = f"{result.dos:.6f}" if result.dos is not None else "NA"
-        values = f"{result.dn}\t{result.ds}\t{result.pn}\t{result.ps}\t{result.p_value:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}"
+        values = (
+            f"{result.dn}\t{result.ds}\t{result.pn}\t{result.ps}\t{result.p_value:.6g}\t"
+            f"{ni_str}\t{alpha_str}\t{dos_str}\t"
+            f"{_omega_tsv_columns(result)}"
+        )
         return f"{header}\n{values}"
 
     elif isinstance(result, PolarizedMKResult):
-        header = "lineage\tDn\tDs\tPn\tPs\tp_value\tNI\talpha\tDoS"
+        header = "lineage\tDn\tDs\tPn\tPs\tp_value\tNI\talpha\tDoS\tLn\tLs\tomega"
         lines = [header]
 
         ni_str = f"{result.ni_ingroup:.6f}" if result.ni_ingroup is not None else "NA"
         alpha_str = f"{result.alpha_ingroup:.6f}" if result.alpha_ingroup is not None else "NA"
         dos_str = f"{result.dos_ingroup:.6f}" if result.dos_ingroup is not None else "NA"
+        ln_s = _fmt_optional(result.ln)
+        ls_s = _fmt_optional(result.ls)
         lines.append(
             f"ingroup\t{result.dn_ingroup}\t{result.ds_ingroup}\t"
             f"{result.pn_ingroup}\t{result.ps_ingroup}\t"
-            f"{result.p_value_ingroup:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}"
+            f"{result.p_value_ingroup:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}\t"
+            f"{_omega_tsv_columns(result)}"
         )
-        lines.append(f"outgroup\t{result.dn_outgroup}\t{result.ds_outgroup}\tNA\tNA\tNA\tNA\tNA\tNA")
         lines.append(
-            f"unpolarized\t{result.dn_unpolarized}\t{result.ds_unpolarized}\tNA\tNA\tNA\tNA\tNA\tNA"
+            f"outgroup\t{result.dn_outgroup}\t{result.ds_outgroup}\tNA\tNA\tNA\tNA\tNA\tNA\t"
+            f"{ln_s}\t{ls_s}\tNA"
+        )
+        lines.append(
+            f"unpolarized\t{result.dn_unpolarized}\t{result.ds_unpolarized}\t"
+            f"NA\tNA\tNA\tNA\tNA\tNA\t{ln_s}\t{ls_s}\tNA"
         )
         return "\n".join(lines)
 
     elif isinstance(result, AsymptoticMKResult):
         if result.num_genes > 0:
             # Aggregated result
-            header = "Dn\tDs\tPn\tPs\talpha_asymptotic\tCI_low\tCI_high\tmodel\tnum_genes"
+            header = (
+                "Dn\tDs\tPn\tPs\talpha_asymptotic\tCI_low\tCI_high\tmodel\tnum_genes\t"
+                "Ln\tLs\tomega\tomega_a\tomega_na"
+            )
             values = (
                 f"{result.dn}\t{result.ds}\t{result.pn_total}\t{result.ps_total}\t"
                 f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
-                f"{result.model_type}\t{result.num_genes}"
+                f"{result.model_type}\t{result.num_genes}\t"
+                f"{_omega_full_tsv_columns(result)}"
             )
         else:
-            header = "Dn\tDs\talpha_asymptotic\tCI_low\tCI_high"
+            header = "Dn\tDs\talpha_asymptotic\tCI_low\tCI_high\tLn\tLs\tomega\tomega_a\tomega_na"
             values = (
                 f"{result.dn}\t{result.ds}\t{result.alpha_asymptotic:.6f}\t"
-                f"{result.ci_low:.6f}\t{result.ci_high:.6f}"
+                f"{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
+                f"{_omega_full_tsv_columns(result)}"
             )
         return f"{header}\n{values}"
 
     elif isinstance(result, AlphaTGResult):
-        header = "Dn\tDs\tPn\tPs\talpha_TG\tNI_TG\tCI_low\tCI_high\tnum_genes"
+        header = (
+            "Dn\tDs\tPn\tPs\talpha_TG\tNI_TG\tCI_low\tCI_high\tnum_genes\t"
+            "Ln\tLs\tomega\tomega_a\tomega_na"
+        )
         values = (
             f"{result.dn_total}\t{result.ds_total}\t{result.pn_total}\t{result.ps_total}\t"
             f"{result.alpha_tg:.6f}\t{result.ni_tg:.6f}\t{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
-            f"{result.num_genes}"
+            f"{result.num_genes}\t"
+            f"{_omega_full_tsv_columns(result)}"
         )
         return f"{header}\n{values}"
 
@@ -168,65 +218,74 @@ def format_batch_results(
         # Check type of first result
         _, first_result = results[0]
         if isinstance(first_result, MKResult):
+            base_header = "gene\tDn\tDs\tPn\tPs\tp_value"
             if adjusted_pvalues is not None:
-                header = "gene\tDn\tDs\tPn\tPs\tp_value\tp_value_adjusted\tNI\talpha\tDoS"
-            else:
-                header = "gene\tDn\tDs\tPn\tPs\tp_value\tNI\talpha\tDoS"
+                base_header += "\tp_value_adjusted"
+            header = base_header + "\tNI\talpha\tDoS\tLn\tLs\tomega"
             lines = [header]
             for i, (name, result) in enumerate(results):
                 if isinstance(result, MKResult):
                     ni_str = f"{result.ni:.6f}" if result.ni is not None else "NA"
                     alpha_str = f"{result.alpha:.6f}" if result.alpha is not None else "NA"
                     dos_str = f"{result.dos:.6f}" if result.dos is not None else "NA"
+                    base_row = (
+                        f"{name}\t{result.dn}\t{result.ds}\t{result.pn}\t{result.ps}\t"
+                        f"{result.p_value:.6g}"
+                    )
                     if adjusted_pvalues is not None:
-                        lines.append(
-                            f"{name}\t{result.dn}\t{result.ds}\t{result.pn}\t{result.ps}\t"
-                            f"{result.p_value:.6g}\t{adjusted_pvalues[i]:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}"
-                        )
-                    else:
-                        lines.append(
-                            f"{name}\t{result.dn}\t{result.ds}\t{result.pn}\t{result.ps}\t"
-                            f"{result.p_value:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}"
-                        )
+                        base_row += f"\t{adjusted_pvalues[i]:.6g}"
+                    lines.append(
+                        f"{base_row}\t{ni_str}\t{alpha_str}\t{dos_str}\t"
+                        f"{_omega_tsv_columns(result)}"
+                    )
             return "\n".join(lines)
 
         elif isinstance(first_result, AsymptoticMKResult):
-            header = "gene\tDn\tDs\talpha_asymptotic\tCI_low\tCI_high\tmodel"
+            header = (
+                "gene\tDn\tDs\talpha_asymptotic\tCI_low\tCI_high\tmodel\t"
+                "Ln\tLs\tomega\tomega_a\tomega_na"
+            )
             lines = [header]
             for name, result in results:
                 if isinstance(result, AsymptoticMKResult):
                     lines.append(
                         f"{name}\t{result.dn}\t{result.ds}\t"
                         f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t"
-                        f"{result.ci_high:.6f}\t{result.model_type}"
+                        f"{result.ci_high:.6f}\t{result.model_type}\t"
+                        f"{_omega_full_tsv_columns(result)}"
                     )
             return "\n".join(lines)
 
         elif isinstance(first_result, PolarizedMKResult):
+            base_header = (
+                "gene\tDn_ingroup\tDs_ingroup\tPn_ingroup\tPs_ingroup\t"
+                "Dn_outgroup\tDs_outgroup\tp_value"
+            )
             if adjusted_pvalues is not None:
-                header = "gene\tDn_ingroup\tDs_ingroup\tPn_ingroup\tPs_ingroup\tDn_outgroup\tDs_outgroup\tp_value\tp_value_adjusted\tNI\talpha\tDoS"
-            else:
-                header = "gene\tDn_ingroup\tDs_ingroup\tPn_ingroup\tPs_ingroup\tDn_outgroup\tDs_outgroup\tp_value\tNI\talpha\tDoS"
+                base_header += "\tp_value_adjusted"
+            header = base_header + "\tNI\talpha\tDoS\tLn\tLs\tomega"
             lines = [header]
             for i, (name, result) in enumerate(results):
                 if isinstance(result, PolarizedMKResult):
                     ni_str = f"{result.ni_ingroup:.6f}" if result.ni_ingroup is not None else "NA"
-                    alpha_str = f"{result.alpha_ingroup:.6f}" if result.alpha_ingroup is not None else "NA"
-                    dos_str = f"{result.dos_ingroup:.6f}" if result.dos_ingroup is not None else "NA"
+                    alpha_str = (
+                        f"{result.alpha_ingroup:.6f}" if result.alpha_ingroup is not None else "NA"
+                    )
+                    dos_str = (
+                        f"{result.dos_ingroup:.6f}" if result.dos_ingroup is not None else "NA"
+                    )
+                    base_row = (
+                        f"{name}\t{result.dn_ingroup}\t{result.ds_ingroup}\t"
+                        f"{result.pn_ingroup}\t{result.ps_ingroup}\t"
+                        f"{result.dn_outgroup}\t{result.ds_outgroup}\t"
+                        f"{result.p_value_ingroup:.6g}"
+                    )
                     if adjusted_pvalues is not None:
-                        lines.append(
-                            f"{name}\t{result.dn_ingroup}\t{result.ds_ingroup}\t"
-                            f"{result.pn_ingroup}\t{result.ps_ingroup}\t"
-                            f"{result.dn_outgroup}\t{result.ds_outgroup}\t"
-                            f"{result.p_value_ingroup:.6g}\t{adjusted_pvalues[i]:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}"
-                        )
-                    else:
-                        lines.append(
-                            f"{name}\t{result.dn_ingroup}\t{result.ds_ingroup}\t"
-                            f"{result.pn_ingroup}\t{result.ps_ingroup}\t"
-                            f"{result.dn_outgroup}\t{result.ds_outgroup}\t"
-                            f"{result.p_value_ingroup:.6g}\t{ni_str}\t{alpha_str}\t{dos_str}"
-                        )
+                        base_row += f"\t{adjusted_pvalues[i]:.6g}"
+                    lines.append(
+                        f"{base_row}\t{ni_str}\t{alpha_str}\t{dos_str}\t"
+                        f"{_omega_tsv_columns(result)}"
+                    )
             return "\n".join(lines)
 
         else:

--- a/src/mkado/io/output.py
+++ b/src/mkado/io/output.py
@@ -40,6 +40,16 @@ def _omega_full_tsv_columns(
     )
 
 
+def _omega_a_na_ci_tsv_columns(
+    result: AsymptoticMKResult | AlphaTGResult,
+) -> str:
+    """Tab-separated CI columns for omega_a and omega_na."""
+    return (
+        f"{_fmt_optional(result.omega_a_ci_low)}\t{_fmt_optional(result.omega_a_ci_high)}\t"
+        f"{_fmt_optional(result.omega_na_ci_low)}\t{_fmt_optional(result.omega_na_ci_high)}"
+    )
+
+
 def _omega_tsv_columns(result: MKResult | PolarizedMKResult) -> str:
     """Tab-separated ``Ln\\tLs\\tomega`` for omega-only result types (MK, polarized)."""
     return (
@@ -134,37 +144,47 @@ def _format_tsv(result: MKResult | PolarizedMKResult | AsymptoticMKResult | Alph
         return "\n".join(lines)
 
     elif isinstance(result, AsymptoticMKResult):
+        ci_cols = "\tomega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
         if result.num_genes > 0:
             # Aggregated result
             header = (
                 "Dn\tDs\tPn\tPs\talpha_asymptotic\tCI_low\tCI_high\tmodel\tnum_genes\t"
-                "Ln\tLs\tomega\tomega_a\tomega_na"
+                "Ln\tLs\tomega\tomega_a\tomega_na" + ci_cols
             )
             values = (
                 f"{result.dn}\t{result.ds}\t{result.pn_total}\t{result.ps_total}\t"
                 f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
                 f"{result.model_type}\t{result.num_genes}\t"
-                f"{_omega_full_tsv_columns(result)}"
+                f"{_omega_full_tsv_columns(result)}\t"
+                f"{_omega_a_na_ci_tsv_columns(result)}"
             )
         else:
-            header = "Dn\tDs\talpha_asymptotic\tCI_low\tCI_high\tLn\tLs\tomega\tomega_a\tomega_na"
+            header = (
+                "Dn\tDs\talpha_asymptotic\tCI_low\tCI_high\t"
+                "Ln\tLs\tomega\tomega_a\tomega_na" + ci_cols
+            )
             values = (
                 f"{result.dn}\t{result.ds}\t{result.alpha_asymptotic:.6f}\t"
                 f"{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
-                f"{_omega_full_tsv_columns(result)}"
+                f"{_omega_full_tsv_columns(result)}\t"
+                f"{_omega_a_na_ci_tsv_columns(result)}"
             )
         return f"{header}\n{values}"
 
     elif isinstance(result, AlphaTGResult):
         header = (
             "Dn\tDs\tPn\tPs\talpha_TG\tNI_TG\tCI_low\tCI_high\tnum_genes\t"
-            "Ln\tLs\tomega\tomega_a\tomega_na"
+            "Ln\tLs\tomega\tomega_a\tomega_na\t"
+            "omega_CI_low\tomega_CI_high\t"
+            "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
         )
         values = (
             f"{result.dn_total}\t{result.ds_total}\t{result.pn_total}\t{result.ps_total}\t"
             f"{result.alpha_tg:.6f}\t{result.ni_tg:.6f}\t{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
             f"{result.num_genes}\t"
-            f"{_omega_full_tsv_columns(result)}"
+            f"{_omega_full_tsv_columns(result)}\t"
+            f"{_fmt_optional(result.omega_ci_low)}\t{_fmt_optional(result.omega_ci_high)}\t"
+            f"{_omega_a_na_ci_tsv_columns(result)}"
         )
         return f"{header}\n{values}"
 
@@ -243,7 +263,8 @@ def format_batch_results(
         elif isinstance(first_result, AsymptoticMKResult):
             header = (
                 "gene\tDn\tDs\talpha_asymptotic\tCI_low\tCI_high\tmodel\t"
-                "Ln\tLs\tomega\tomega_a\tomega_na"
+                "Ln\tLs\tomega\tomega_a\tomega_na\t"
+                "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
             )
             lines = [header]
             for name, result in results:
@@ -252,7 +273,8 @@ def format_batch_results(
                         f"{name}\t{result.dn}\t{result.ds}\t"
                         f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t"
                         f"{result.ci_high:.6f}\t{result.model_type}\t"
-                        f"{_omega_full_tsv_columns(result)}"
+                        f"{_omega_full_tsv_columns(result)}\t"
+                        f"{_omega_a_na_ci_tsv_columns(result)}"
                     )
             return "\n".join(lines)
 

--- a/tests/test_imputed.py
+++ b/tests/test_imputed.py
@@ -379,7 +379,10 @@ class TestImputedMKResult:
         tsv = format_result(result, OutputFormat.TSV)
         header, values = tsv.split("\n")
 
-        assert "Dn\tDs\tPn\tPs\tPwd\tPn_neutral\talpha\tp_value\tcutoff" == header
+        assert (
+            "Dn\tDs\tPn\tPs\tPwd\tPn_neutral\talpha\tp_value\tcutoff\t"
+            "Ln\tLs\tomega\tomega_a\tomega_na"
+        ) == header
         fields = values.split("\t")
         assert fields[0] == "7"   # Dn
         assert fields[1] == "5"   # Ds

--- a/tests/test_omega.py
+++ b/tests/test_omega.py
@@ -314,6 +314,148 @@ class TestAlphaTGOmega:
 
 
 # ---------------------------------------------------------------------------
+# Bootstrap CIs on omega_a / omega_na (and on omega for alpha_tg)
+# ---------------------------------------------------------------------------
+
+
+class TestAsymptoticOmegaCIs:
+    """AsymptoticMKResult exposes omega_a/omega_na CIs scaled from the alpha CI.
+
+    Dn, Ds, Ln, Ls are constants under the curve-fit Monte Carlo, so omega
+    itself has no sampling distribution. omega_a = alpha * omega scales the
+    alpha CI directly; omega_na flips the percentiles since (1 - alpha)
+    inverts the ordering.
+    """
+
+    def _build_result(self):
+        gene = PolymorphismData(
+            polymorphisms=[(0.5, "S")] * 10 + [(0.5, "N")] * 10,
+            dn=10,
+            ds=10,
+            ln=200.0,
+            ls=100.0,
+        )
+        return asymptotic_mk_test_aggregated([gene] * 5, num_bins=10)
+
+    def test_ci_fields_present(self) -> None:
+        result = self._build_result()
+        for attr in (
+            "omega_a_ci_low",
+            "omega_a_ci_high",
+            "omega_na_ci_low",
+            "omega_na_ci_high",
+        ):
+            assert hasattr(result, attr), f"missing {attr}"
+
+    def test_omega_a_ci_scales_alpha_ci(self) -> None:
+        result = self._build_result()
+        if result.omega is None:
+            pytest.skip("omega undefined for this fixture")
+        assert result.omega_a_ci_low == pytest.approx(result.ci_low * result.omega)
+        assert result.omega_a_ci_high == pytest.approx(result.ci_high * result.omega)
+
+    def test_omega_na_ci_flips_alpha_ci(self) -> None:
+        result = self._build_result()
+        if result.omega is None:
+            pytest.skip("omega undefined for this fixture")
+        # omega_na = (1 - alpha) * omega; since (1-x) is monotonically
+        # decreasing, the low/high quantiles flip.
+        assert result.omega_na_ci_low == pytest.approx((1.0 - result.ci_high) * result.omega)
+        assert result.omega_na_ci_high == pytest.approx((1.0 - result.ci_low) * result.omega)
+
+    def test_to_dict_includes_ci_keys(self) -> None:
+        result = self._build_result()
+        d = result.to_dict()
+        for key in (
+            "omega_a_ci_low",
+            "omega_a_ci_high",
+            "omega_na_ci_low",
+            "omega_na_ci_high",
+        ):
+            assert key in d
+
+
+class TestAlphaTGOmegaCIs:
+    """AlphaTGResult bootstraps genes, so omega itself varies per replicate."""
+
+    def _gene_data(self):
+        return [
+            PolymorphismData(
+                polymorphisms=[(0.2, "N")] * 5 + [(0.5, "S")] * 15,
+                dn=10,
+                ds=20,
+                ln=200.0,
+                ls=100.0,
+            ),
+            PolymorphismData(
+                polymorphisms=[(0.3, "N")] * 3 + [(0.5, "S")] * 10,
+                dn=8,
+                ds=16,
+                ln=150.0,
+                ls=75.0,
+            ),
+            PolymorphismData(
+                polymorphisms=[(0.1, "N")] * 7 + [(0.5, "S")] * 12,
+                dn=6,
+                ds=14,
+                ln=180.0,
+                ls=90.0,
+            ),
+        ]
+
+    def test_ci_fields_present(self) -> None:
+        result = alpha_tg_from_gene_data(self._gene_data(), bootstrap_replicates=200, seed=42)
+        for attr in (
+            "omega_ci_low",
+            "omega_ci_high",
+            "omega_a_ci_low",
+            "omega_a_ci_high",
+            "omega_na_ci_low",
+            "omega_na_ci_high",
+        ):
+            assert hasattr(result, attr), f"missing {attr}"
+
+    def test_cis_bracket_point_estimates(self) -> None:
+        result = alpha_tg_from_gene_data(self._gene_data(), bootstrap_replicates=500, seed=42)
+        assert result.omega is not None
+        # Point estimates should fall within the bootstrap CI in nearly all cases.
+        # With 3 genes the bootstrap is noisy, so we just check the CI is a valid
+        # interval (low <= high) and brackets the point estimate.
+        assert result.omega_ci_low <= result.omega_ci_high
+        assert result.omega_a_ci_low <= result.omega_a_ci_high
+        assert result.omega_na_ci_low <= result.omega_na_ci_high
+
+    def test_to_dict_includes_ci_keys(self) -> None:
+        result = alpha_tg_from_gene_data(self._gene_data(), bootstrap_replicates=10, seed=42)
+        d = result.to_dict()
+        for key in (
+            "omega_ci_low",
+            "omega_ci_high",
+            "omega_a_ci_low",
+            "omega_a_ci_high",
+            "omega_na_ci_low",
+            "omega_na_ci_high",
+        ):
+            assert key in d
+
+    def test_cis_none_when_sites_missing(self) -> None:
+        # If any gene lacks site counts, omega_total is None and so are the CIs.
+        gene_data = [
+            PolymorphismData(
+                polymorphisms=[(0.2, "N")] * 5,
+                dn=10,
+                ds=20,
+                # no ln/ls
+            ),
+        ]
+        result = alpha_tg_from_gene_data(gene_data, bootstrap_replicates=10, seed=42)
+        assert result.omega is None
+        assert result.omega_ci_low is None
+        assert result.omega_a_ci_low is None
+        assert result.omega_na_ci_low is None
+
+
+# ---------------------------------------------------------------------------
 # extract_polymorphism_data populates Ln/Ls
 # ---------------------------------------------------------------------------
 

--- a/tests/test_omega.py
+++ b/tests/test_omega.py
@@ -20,7 +20,6 @@ from mkado.analysis.mk_test import mk_test, mk_test_from_counts
 from mkado.analysis.polarized import polarized_mk_test
 from mkado.analysis.statistics import omega_decomposition
 from mkado.core.alignment import AlignedPair
-from mkado.core.codons import DEFAULT_CODE
 from mkado.core.sequences import Sequence, SequenceSet
 
 

--- a/tests/test_omega.py
+++ b/tests/test_omega.py
@@ -1,0 +1,340 @@
+"""Tests for Ls/Ln site counts and omega/omega_a/omega_na decomposition.
+
+Covers issue #9: surface Nei-Gojobori Ls/Ln totals and report omega
+(Coronado-Zamora et al. 2019) on every result dataclass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mkado.analysis.alpha_tg import alpha_tg_from_gene_data
+from mkado.analysis.asymptotic import (
+    PolymorphismData,
+    aggregate_polymorphism_data,
+    asymptotic_mk_test_aggregated,
+    extract_polymorphism_data,
+)
+from mkado.analysis.imputed import imputed_mk_test
+from mkado.analysis.mk_test import mk_test, mk_test_from_counts
+from mkado.analysis.polarized import polarized_mk_test
+from mkado.analysis.statistics import omega_decomposition
+from mkado.core.alignment import AlignedPair
+from mkado.core.codons import DEFAULT_CODE
+from mkado.core.sequences import Sequence, SequenceSet
+
+
+def _seqset(*seqs: tuple[str, str]) -> SequenceSet:
+    return SequenceSet(sequences=[Sequence(name=n, sequence=s) for n, s in seqs])
+
+
+# ---------------------------------------------------------------------------
+# Site counting on AlignedPair
+# ---------------------------------------------------------------------------
+
+
+class TestCountTotalSites:
+    """count_total_sites aggregates Nei-Gojobori per-codon syn fractions."""
+
+    def test_methionine_only(self) -> None:
+        # ATG (Met) has no synonymous sites under the standard code.
+        # Two ATG codons -> Ls = 0, Ln = 6
+        ingroup = _seqset(("i1", "ATGATG"))
+        outgroup = _seqset(("o1", "ATGATG"))
+        pair = AlignedPair(ingroup=ingroup, outgroup=outgroup)
+
+        ln, ls = pair.count_total_sites()
+        assert ls == pytest.approx(0.0)
+        assert ln == pytest.approx(6.0)
+
+    def test_phenylalanine_codon(self) -> None:
+        # TTT (Phe): site 3 has 1/3 synonymous (only TTC -> Phe). Other sites
+        # are zero. So Ls(TTT) = 1/3.
+        ingroup = _seqset(("i1", "TTT"))
+        outgroup = _seqset(("o1", "TTT"))
+        pair = AlignedPair(ingroup=ingroup, outgroup=outgroup)
+
+        ln, ls = pair.count_total_sites()
+        assert ls == pytest.approx(1.0 / 3.0)
+        assert ln == pytest.approx(3.0 - 1.0 / 3.0)
+
+    def test_skips_codons_with_no_clean_codons(self) -> None:
+        # First codon is fully ambiguous in both groups -> not counted.
+        ingroup = _seqset(("i1", "NNNATG"))
+        outgroup = _seqset(("o1", "NNNATG"))
+        pair = AlignedPair(ingroup=ingroup, outgroup=outgroup)
+
+        ln, ls = pair.count_total_sites()
+        # Only one analyzed codon (ATG): Ln=3, Ls=0
+        assert ls == pytest.approx(0.0)
+        assert ln == pytest.approx(3.0)
+
+    def test_averages_across_groups(self) -> None:
+        # Ingroup ATG, outgroup TTT -> averaged Ls = (0 + 1/3) / 2
+        ingroup = _seqset(("i1", "ATG"))
+        outgroup = _seqset(("o1", "TTT"))
+        pair = AlignedPair(ingroup=ingroup, outgroup=outgroup)
+
+        ln, ls = pair.count_total_sites()
+        assert ls == pytest.approx((0.0 + 1.0 / 3.0) / 2.0)
+        assert ln == pytest.approx(3.0 - ls)
+
+
+# ---------------------------------------------------------------------------
+# omega_decomposition helper
+# ---------------------------------------------------------------------------
+
+
+class TestOmegaDecomposition:
+    """omega_decomposition returns (omega, omega_a, omega_na)."""
+
+    def test_basic(self) -> None:
+        # Dn=10, Ds=5, Ln=200, Ls=100 -> omega = (10/5) * (100/200) = 1.0
+        # alpha=0.5 -> omega_a=0.5, omega_na=0.5
+        omega, omega_a, omega_na = omega_decomposition(10, 5, 200.0, 100.0, 0.5)
+        assert omega == pytest.approx(1.0)
+        assert omega_a == pytest.approx(0.5)
+        assert omega_na == pytest.approx(0.5)
+
+    def test_alpha_none_propagates_to_a_and_na(self) -> None:
+        omega, omega_a, omega_na = omega_decomposition(10, 5, 200.0, 100.0, None)
+        assert omega == pytest.approx(1.0)
+        assert omega_a is None
+        assert omega_na is None
+
+    def test_zero_ds_is_none(self) -> None:
+        result = omega_decomposition(10, 0, 200.0, 100.0, 0.5)
+        assert result == (None, None, None)
+
+    def test_zero_ls_is_none(self) -> None:
+        result = omega_decomposition(10, 5, 200.0, 0.0, 0.5)
+        assert result == (None, None, None)
+
+    def test_zero_ln_is_none(self) -> None:
+        result = omega_decomposition(10, 5, 0.0, 100.0, 0.5)
+        assert result == (None, None, None)
+
+    def test_missing_site_counts(self) -> None:
+        result = omega_decomposition(10, 5, None, None, 0.5)
+        assert result == (None, None, None)
+
+    def test_alpha_zero(self) -> None:
+        omega, omega_a, omega_na = omega_decomposition(10, 5, 200.0, 100.0, 0.0)
+        assert omega_a == pytest.approx(0.0)
+        assert omega_na == pytest.approx(omega)
+
+
+# ---------------------------------------------------------------------------
+# MKResult fields
+# ---------------------------------------------------------------------------
+
+
+class TestMKResultOmega:
+    """MKResult exposes ln/ls/omega but deliberately omits omega_a/omega_na.
+
+    Per-gene Smith-Eyre-Walker alpha is too noisy for a meaningful rate
+    decomposition; see docs/omega.rst.
+    """
+
+    def test_from_counts_with_sites(self) -> None:
+        result = mk_test_from_counts(dn=10, ds=5, pn=4, ps=8, ln=200.0, ls=100.0)
+        assert result.ln == pytest.approx(200.0)
+        assert result.ls == pytest.approx(100.0)
+        # omega = (10/5) * (100/200) = 1.0
+        assert result.omega == pytest.approx(1.0)
+        # alpha = 1 - (5*4)/(10*8) = 1 - 0.25 = 0.75
+        assert result.alpha == pytest.approx(0.75)
+
+    def test_from_counts_without_sites(self) -> None:
+        result = mk_test_from_counts(dn=10, ds=5, pn=4, ps=8)
+        assert result.ln is None
+        assert result.ls is None
+        assert result.omega is None
+
+    def test_from_counts_zero_ds(self) -> None:
+        # With ds=0, omega is undefined
+        result = mk_test_from_counts(dn=10, ds=0, pn=4, ps=8, ln=200.0, ls=100.0)
+        assert result.omega is None
+
+    def test_to_dict_includes_new_keys(self) -> None:
+        result = mk_test_from_counts(dn=10, ds=5, pn=4, ps=8, ln=200.0, ls=100.0)
+        d = result.to_dict()
+        for key in ("ln", "ls", "omega"):
+            assert key in d, f"missing {key} in to_dict()"
+        # omega_a/omega_na deliberately not exposed on per-gene MKResult
+        assert "omega_a" not in d
+        assert "omega_na" not in d
+
+    def test_str_includes_omega(self) -> None:
+        result = mk_test_from_counts(dn=10, ds=5, pn=4, ps=8, ln=200.0, ls=100.0)
+        s = str(result)
+        assert "omega" in s.lower() or "ω" in s
+
+    def test_full_pipeline_populates_sites(self, tmp_path) -> None:
+        # mk_test() should compute Ln/Ls from the alignment automatically.
+        ingroup_fa = tmp_path / "ingroup.fa"
+        ingroup_fa.write_text(">i1\nATGTTTATG\n>i2\nATGTTCATG\n")
+        outgroup_fa = tmp_path / "outgroup.fa"
+        outgroup_fa.write_text(">o1\nATGTTAATG\n")
+
+        result = mk_test(ingroup_fa, outgroup_fa)
+        assert result.ln is not None
+        assert result.ls is not None
+        # 3 codons analyzed -> Ln + Ls = 9
+        assert result.ln + result.ls == pytest.approx(9.0)
+        assert result.ls > 0  # TTT codon contributes synonymous sites
+
+
+# ---------------------------------------------------------------------------
+# AsymptoticMKResult
+# ---------------------------------------------------------------------------
+
+
+class TestAsymptoticOmega:
+    def test_aggregated_carries_sites(self) -> None:
+        # Build PolymorphismData with explicit ln/ls
+        gene = PolymorphismData(
+            polymorphisms=[(0.5, "S")] * 10 + [(0.5, "N")] * 10,
+            dn=10,
+            ds=10,
+            ln=200.0,
+            ls=100.0,
+        )
+        result = asymptotic_mk_test_aggregated([gene] * 5, num_bins=10)
+        # Aggregated totals: ln=1000, ls=500
+        assert result.ln == pytest.approx(1000.0)
+        assert result.ls == pytest.approx(500.0)
+        # Whatever alpha_asymptotic is, omega should be (Dn*Ls)/(Ds*Ln) using totals
+        expected_omega = (result.dn * result.ls) / (result.ds * result.ln)
+        assert result.omega == pytest.approx(expected_omega)
+
+    def test_to_dict_includes_new_keys(self) -> None:
+        gene = PolymorphismData(
+            polymorphisms=[(0.5, "S")] * 5 + [(0.5, "N")] * 5,
+            dn=10,
+            ds=10,
+            ln=200.0,
+            ls=100.0,
+        )
+        result = asymptotic_mk_test_aggregated([gene] * 3, num_bins=5)
+        d = result.to_dict()
+        for key in ("ln", "ls", "omega", "omega_a", "omega_na"):
+            assert key in d
+
+
+# ---------------------------------------------------------------------------
+# PolarizedMKResult
+# ---------------------------------------------------------------------------
+
+
+class TestPolarizedOmega:
+    """PolarizedMKResult exposes ln/ls/omega but omits omega_a/omega_na.
+
+    Per-gene polarized alpha is too noisy for a meaningful rate decomposition;
+    see docs/omega.rst.
+    """
+
+    def test_full_pipeline(self, tmp_path) -> None:
+        ingroup_fa = tmp_path / "ingroup.fa"
+        ingroup_fa.write_text(">i1\nATGTTTATG\n>i2\nATGTTCATG\n")
+        outgroup1_fa = tmp_path / "outgroup1.fa"
+        outgroup1_fa.write_text(">o1\nATGTTAATG\n")
+        outgroup2_fa = tmp_path / "outgroup2.fa"
+        outgroup2_fa.write_text(">o2\nATGTTAATG\n")
+
+        result = polarized_mk_test(ingroup_fa, outgroup1_fa, outgroup2_fa)
+        assert result.ln is not None
+        assert result.ls is not None
+        # Three codons analyzed -> total = 9
+        assert result.ln + result.ls == pytest.approx(9.0)
+        d = result.to_dict()
+        # Site counts are alignment-wide, so live at the top level
+        assert "ln" in d
+        assert "ls" in d
+        # omega is an ingroup-lineage quantity; lives inside the ingroup sub-dict
+        assert "omega" in d["ingroup"]
+        # omega_a / omega_na deliberately not surfaced (per-gene alpha noise)
+        assert "omega_a" not in d["ingroup"]
+        assert "omega_na" not in d["ingroup"]
+
+
+# ---------------------------------------------------------------------------
+# ImputedMKResult
+# ---------------------------------------------------------------------------
+
+
+class TestImputedOmega:
+    def test_uses_polymorphism_data_sites(self) -> None:
+        gene = PolymorphismData(
+            polymorphisms=[(0.05, "N")] * 3 + [(0.50, "N")] * 5 + [(0.50, "S")] * 8,
+            dn=10,
+            ds=5,
+            ln=200.0,
+            ls=100.0,
+        )
+        result = imputed_mk_test(gene, cutoff=0.15)
+        assert result.ln == pytest.approx(200.0)
+        assert result.ls == pytest.approx(100.0)
+        # omega = (10/5) * (100/200) = 1.0
+        assert result.omega == pytest.approx(1.0)
+        d = result.to_dict()
+        assert "omega" in d
+
+
+# ---------------------------------------------------------------------------
+# AlphaTGResult
+# ---------------------------------------------------------------------------
+
+
+class TestAlphaTGOmega:
+    def test_aggregates_sites_across_genes(self) -> None:
+        gene1 = PolymorphismData(
+            polymorphisms=[(0.2, "N")] * 5 + [(0.5, "S")] * 15,
+            dn=10,
+            ds=20,
+            ln=200.0,
+            ls=100.0,
+        )
+        gene2 = PolymorphismData(
+            polymorphisms=[(0.3, "N")] * 3 + [(0.5, "S")] * 10,
+            dn=8,
+            ds=16,
+            ln=150.0,
+            ls=75.0,
+        )
+        result = alpha_tg_from_gene_data([gene1, gene2], bootstrap_replicates=10, seed=42)
+        assert result.ln == pytest.approx(350.0)
+        assert result.ls == pytest.approx(175.0)
+        # omega from totals
+        expected_omega = (result.dn_total * result.ls) / (result.ds_total * result.ln)
+        assert result.omega == pytest.approx(expected_omega)
+        d = result.to_dict()
+        assert "ln" in d
+        assert "omega" in d
+
+
+# ---------------------------------------------------------------------------
+# extract_polymorphism_data populates Ln/Ls
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPolymorphismDataSites:
+    def test_populates_sites(self, tmp_path) -> None:
+        ingroup_fa = tmp_path / "ingroup.fa"
+        ingroup_fa.write_text(">i1\nATGTTTATG\n>i2\nATGTTCATG\n")
+        outgroup_fa = tmp_path / "outgroup.fa"
+        outgroup_fa.write_text(">o1\nATGTTAATG\n")
+
+        gene = extract_polymorphism_data(ingroup_fa, outgroup_fa)
+        assert gene.ln is not None
+        assert gene.ls is not None
+        assert gene.ln + gene.ls == pytest.approx(9.0)
+
+
+class TestAggregatePolymorphismData:
+    def test_sums_sites(self) -> None:
+        gene1 = PolymorphismData(polymorphisms=[], dn=0, ds=0, ln=200.0, ls=100.0)
+        gene2 = PolymorphismData(polymorphisms=[], dn=0, ds=0, ln=150.0, ls=75.0)
+        agg = aggregate_polymorphism_data([gene1, gene2], num_bins=5)
+        assert agg.ln_total == pytest.approx(350.0)
+        assert agg.ls_total == pytest.approx(175.0)


### PR DESCRIPTION
## Summary

Closes #9 (reviewer point 6 on Ls/Ln site counts and the omega decomposition).

- Adds Nei-Gojobori `Ln` and `Ls` totals to every result dataclass (`MKResult`, `AsymptoticMKResult`, `PolarizedMKResult`, `ImputedMKResult`, `AlphaTGResult`)
- Adds `omega = (Dn/Ds) * (Ls/Ln)` to all five
- Adds `omega_a = alpha * omega` and `omega_na = (1 - alpha) * omega` to the three result types whose alpha estimator is appropriate for the rate decomposition (asymptotic, imputed, alpha-TG). `MKResult` and `PolarizedMKResult` deliberately omit `omega_a`/`omega_na` — per-gene Smith-Eyre-Walker / polarized alpha is too noisy. Rationale documented in [docs/omega.rst](docs/omega.rst).
- Adds 95% CIs on `omega_a`/`omega_na` (analytical scaling for asymptotic; bootstrap for alpha-TG including a CI on `omega` itself since the gene-resampling varies Dn/Ds/Ln/Ls). ImputedMKResult reports point estimates only.
- Pretty / TSV / JSON formatters all surface the new fields.
- Adds `docs/omega.rst` with the math, a Nei-Gojobori vs F3×4 caveat, and the per-gene scoping decision matrix; mentions added to `asymptotic.rst`, `alpha-tg.rst`, `imputed.rst`, `tutorial.rst`, `index.rst`.

## Citations

The reviewer pointed to Coronado-Zamora et al. (2019) for the decomposition. The form `omega_a = alpha * omega` was actually introduced earlier by **Gossmann, Keightley & Eyre-Walker (2012, GBE 4(5):658-667)**, but Coronado-Zamora applied it to MK-style fixed/polymorphic counts (the form mkado computes). Both are cited prominently in `docs/omega.rst`, the per-test pages, and the `omega_decomposition` docstring.

## Performance

Adding `count_total_sites()` would have doubled the codon-iteration work in MK tests. To avoid that, `SequenceSet.codon_set_clean()` is now memoized per-instance and `GeneticCode.count_synonymous_sites()` got a similar per-instance cache. Net effect on a 500-codon × 50-sequence alignment:

- `count_total_sites()` cache-hit: **21 ms → 2.8 ms** (7.4×)
- Full `mk_test()` end-to-end: **47 ms → 39 ms** (~18%)

## Scope decisions worth flagging

- **`MKResult` / `PolarizedMKResult` omit `omega_a`/`omega_na`** — per-gene S-EW / polarized alpha is too noisy for a meaningful rate decomposition. Per-gene `omega` (i.e. dN/dS) is fine and is reported. Documented in `docs/omega.rst`.
- **Site counting is Nei-Gojobori, not F3×4** — Gossmann et al. used PAML's F3×4. The decomposition formula is identical, but the resulting numbers aren't strictly comparable to F3×4-based ω_a literature. Documented as a `.. note::` in `docs/omega.rst`.

## Follow-ups filed (out of scope here)

- #13 — standardize `\"NA\"` vs `\"N/A\"` rendering across pretty/TSV outputs (pre-existing inconsistency that this PR propagates)
- #14 — `GeneticCode.translate` still uses `@lru_cache` on a bound method (same antipattern fix as `count_synonymous_sites` in this PR)

## Test plan

- [x] `uv run pytest --ignore=tests/test_cli.py --ignore=tests/test_batch.py --ignore=tests/test_vcf.py` — 199/199 pass (test_cli/batch/vcf collection error is a pre-existing dev-env issue unrelated to this PR)
- [x] `uv run ruff check src/mkado/analysis/ src/mkado/core/ src/mkado/io/output.py` — clean (remaining warnings are pre-existing in `plotting.py`)
- [x] `uv run ruff format --check` on touched files — clean
- [x] `cd docs && sphinx-build -W --keep-going -b html . _build/html` — strict build succeeds, no warnings
- [x] CLI smoke tests on `tests/data/kreitmanAdh.fa` for pretty / TSV / JSON output across all five test types
- [x] New `tests/test_omega.py` with 32 tests covering hand-calculated fixtures, edge cases (`Ds=0`, `Ls=0`, missing site counts), CI shapes, and end-to-end pipeline behavior