### PR TITLE
Add multinomial-style bootstrap CI for MK tests (closes #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@
   totals over analyzed codons.
 - `Ln`, `Ls`, `omega`, `omega_a`, and `omega_na` columns in pretty,
   TSV, and JSON output for all result types.
+- `--ci-method {monte-carlo,bootstrap}` CLI flag on `test`, `batch`, and
+  `vcf` commands. The new `bootstrap` mode uses case-resampling of the
+  pooled polymorphism list with replacement, refitting the curve per
+  replicate (closes #10). Default remains `monte-carlo` to preserve
+  existing behavior. Each result type now records the CI method via a
+  `ci_method` field on `AsymptoticMKResult` (default `"monte-carlo"`),
+  `AlphaTGResult` (`"bootstrap"`), and `ImputedMKResult`
+  (`"bootstrap"` when set, `None` when no CI was computed).
+- Bootstrap CI on imputed-MK alpha. `imputed_mk_test` and
+  `imputed_mk_test_multi` now accept `n_bootstrap: int = 0` (preserves
+  legacy behavior when 0) and `seed: int = 42`. CLI: enabled
+  automatically when `--bootstrap > 0` (the existing flag drives the
+  replicate count). New fields on `ImputedMKResult`:
+  `alpha_ci_low/high`, `omega_a_ci_low/high`, `omega_na_ci_low/high`,
+  `ci_method`. Following the asymptotic CI pattern, omega-decomposition
+  CIs are derived analytically from the alpha CI scaled by omega.
+- `_compute_ci_bootstrap()` helper in `mkado.analysis.asymptotic`
+  alongside the existing `_compute_ci_monte_carlo()`.
+- `_bootstrap_imputed_alpha()` helper in `mkado.analysis.imputed`.
 
 ## [0.4.0] - 2026-03-17
 

--- a/docs/alpha-tg.rst
+++ b/docs/alpha-tg.rst
@@ -69,6 +69,9 @@ The output includes:
   Ln, and Ls per replicate, omega itself has a bootstrap distribution here
   (unlike in the asymptotic test where Ln/Ls are constants). See
   :doc:`omega` for the rationale.
+- **ci_method**: always ``"bootstrap"`` for α_TG. The weighted estimator
+  has no parametric Monte Carlo analog, so the global ``--ci-method``
+  flag has no effect when ``--alpha-tg`` is set.
 
 Example output (TSV format, abbreviated):
 

--- a/docs/asymptotic.rst
+++ b/docs/asymptotic.rst
@@ -132,13 +132,45 @@ Batch Analysis (Per-Gene)
    # Separate asymptotic test for each gene
    mkado batch alignments/ -i ingroup -o outgroup -a --per-gene
 
+Confidence Interval Method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For aggregated analyses, MKado offers two CI methods via ``--ci-method``:
+
+- **monte-carlo** (default): samples curve-fit parameters from a
+  multivariate normal of the fit covariance matrix. Fast (the model is
+  evaluated, not refit, per draw) but parametric — assumes the fit
+  uncertainty is well-described by its covariance.
+- **bootstrap**: case-resampling of the pooled polymorphism list with
+  replacement; the curve is refit each replicate. More principled for
+  small per-bin counts (the typical MK setting); slower because each
+  replicate refits.
+
+.. code-block:: bash
+
+   # Default: parametric Monte Carlo CI
+   mkado batch alignments/ -i ingroup -o outgroup -a
+
+   # Bootstrap CI (refit per replicate)
+   mkado batch alignments/ -i ingroup -o outgroup -a --ci-method bootstrap
+
+   # Bootstrap with more replicates
+   mkado batch alignments/ -i ingroup -o outgroup -a --ci-method bootstrap --bootstrap 500
+
+The bootstrap is held to whichever model (exponential or linear) the
+point estimate selected via AIC, so the CI is comparable across methods.
+
+The flag is silently accepted but has no effect on per-gene asymptotic
+runs (those have always used a polymorphism-list bootstrap natively).
+
 Output
 ------
 
 The asymptotic test reports:
 
 - **alpha_asymptotic**: Extrapolated alpha at derived frequency = 1.0
-- **CI_low, CI_high**: 95% bootstrap confidence interval
+- **CI_low, CI_high**: 95% confidence interval (method recorded in ``ci_method``)
+- **ci_method**: ``"monte-carlo"`` (default) or ``"bootstrap"`` (case-resampling)
 - **model_type**: Selected model (exponential or linear)
 - **a, b, c**: Fitted model parameters (c only for exponential)
 - **Ln, Ls**: Nei-Gojobori non-synonymous and synonymous site totals

--- a/docs/batch-workflow.rst
+++ b/docs/batch-workflow.rst
@@ -80,6 +80,18 @@ Aggregated Analysis
 
 This outputs a single asymptotic alpha estimate for the entire gene set.
 
+By default, the 95% CI is computed by sampling parameters from the curve-fit
+covariance matrix (parametric Monte Carlo). Pass ``--ci-method bootstrap``
+for case-resampling of the pooled polymorphism list — slower per replicate
+but more principled for small per-bin counts:
+
+.. code-block:: bash
+
+   # Bootstrap CI (refit per replicate)
+   mkado batch alignments/ -i species1 -o species2 -a --ci-method bootstrap
+
+See :doc:`asymptotic` for when to choose each.
+
 Asymptotic Alpha Plot
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/imputed.rst
+++ b/docs/imputed.rst
@@ -110,6 +110,29 @@ Batch Analysis (Per-Gene)
    # Run imputed test separately for each gene
    mkado batch alignments/ -i ingroup -o outgroup --imputed --per-gene
 
+Bootstrap Confidence Intervals
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``--bootstrap N`` is set (with N > 0), the imputed test runs an
+additional case-resampling bootstrap to produce a 95% CI on alpha. Each
+replicate resamples the polymorphism list with replacement and re-runs
+the imputed MK algorithm; the 2.5/97.5 percentiles of the resulting
+alpha distribution are reported as ``alpha_CI_low`` / ``alpha_CI_high``.
+The omega decomposition CIs are derived from the alpha CI by analytical
+scaling (``omega_a_ci = alpha_ci * omega``), mirroring the asymptotic
+test.
+
+.. code-block:: bash
+
+   # Imputed test with 500-replicate bootstrap
+   mkado test alignment.fa -i ingroup -o outgroup --imputed --bootstrap 500
+
+   # Aggregated imputed batch with bootstrap
+   mkado batch alignments/ -i ingroup -o outgroup --imputed --bootstrap 200
+
+The legacy default (``--bootstrap 100``) computes the bootstrap; pass
+``--bootstrap 0`` to disable CI computation entirely.
+
 Output
 ------
 
@@ -125,9 +148,13 @@ The imputed test reports:
 - **omega, omega_a, omega_na**: dN/dS and the adaptive/non-adaptive
   decomposition (``omega_a = alpha * omega``) following
   `Gossmann, Keightley & Eyre-Walker 2012`_, applied to MK counts by
-  `Coronado-Zamora et al. 2019`_. Reported as point estimates only — the
-  imputed test does not currently bootstrap, so no CIs are produced.
-  See :doc:`omega` for the decomposition formula.
+  `Coronado-Zamora et al. 2019`_. See :doc:`omega` for the decomposition
+  formula.
+- **alpha_CI_low, alpha_CI_high**: 95% bootstrap CI on alpha (when
+  ``--bootstrap > 0``)
+- **omega_a_CI_low/high, omega_na_CI_low/high**: 95% CIs on the omega
+  decomposition, derived from the alpha CI scaled by omega
+- **ci_method**: ``"bootstrap"`` when CI was computed, ``None`` otherwise
 
 Example output (pretty format):
 
@@ -141,8 +168,11 @@ Example output (pretty format):
      Pn (neutral):  6.18
      Alpha:         0.5154
      p-value:       0.0891
+     Alpha 95% CI [bootstrap]: (0.3210, 0.7050)
      Sites:         Ln=576.00, Ls=195.00
      omega:         0.2539 (omega_a=0.1308, omega_na=0.1230)
+       omega_a 95% CI:  (0.0815, 0.1790)
+       omega_na 95% CI: (0.0749, 0.1724)
 
 Comparison with Other Methods
 -----------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Features
 - **Imputed MK test**: Corrects for slightly deleterious mutations by imputation (`Murga-Moreno et al. 2022`_)
 - **Tarone-Greenland α_TG**: Weighted multi-gene estimator (`Stoletzki & Eyre-Walker 2011`_)
 - **Omega decomposition**: dN/dS plus adaptive (ω_a) / non-adaptive (ω_na) rates with 95% CIs (`Gossmann, Keightley & Eyre-Walker 2012`_)
+- **Bootstrap CI option**: ``--ci-method bootstrap`` runs a case-resampling bootstrap as an alternative to the parametric Monte Carlo CI; bootstrap CI on imputed alpha when ``--bootstrap > 0``
 - **Alternate genetic codes**: Support for 24 NCBI genetic code tables (mitochondrial, plastid, etc.)
 - **VCF input**: Go directly from VCF + reference + GFF3 to MK test results
 - **Batch processing**: Process multiple genes with parallel execution

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -139,6 +139,9 @@ The output includes:
 
 - **Alpha asymptotic**: Extrapolated alpha value at derived frequency = 1
 - **95% CI**: Confidence interval for alpha asymptotic
+- **ci_method**: ``"monte-carlo"`` (default — parametric MVN sampling from the
+  fit covariance) or ``"bootstrap"`` (case-resampling). Switch with
+  ``--ci-method bootstrap``. See :doc:`asymptotic` for the trade-offs.
 - **Model type**: Whether exponential or linear model was selected
 - **Per-bin alpha values**: Alpha estimates at each frequency class
 - **omega, omega_a, omega_na**: dN/dS and its adaptive / non-adaptive

--- a/docs/vcf-input.rst
+++ b/docs/vcf-input.rst
@@ -163,6 +163,10 @@ Additional Options
    # Bootstrap replicates for confidence intervals (default: 100)
    mkado vcf ... --asymptotic --bootstrap 500
 
+   # Use case-resampling bootstrap CI instead of the parametric MC default
+   # (meaningful for --asymptotic --aggregate; see :doc:`asymptotic`)
+   mkado vcf ... --asymptotic --ci-method bootstrap
+
    # Frequency cutoffs for asymptotic curve fitting (default: 0.1,0.9)
    mkado vcf ... --asymptotic --freq-cutoffs 0.15,0.85
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ target-version = "py312"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/src/mkado/analysis/alpha_tg.py
+++ b/src/mkado/analysis/alpha_tg.py
@@ -85,12 +85,16 @@ class AlphaTGResult:
     """Lower 95% bootstrap CI for ``omega_na``."""
     omega_na_ci_high: float | None = None
     """Upper 95% bootstrap CI for ``omega_na``."""
+    ci_method: str = "bootstrap"
+    """Method used for the CI. Always ``"bootstrap"`` (gene-level resampling)
+    for ``AlphaTGResult`` — the weighted estimator has no parametric MC analog."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation."""
         lines = [
             "Tarone-Greenland Alpha (Stoletzki & Eyre-Walker 2011):",
-            f"  α_TG:  {self.alpha_tg:.4f} (95% CI: {self.ci_low:.4f} - {self.ci_high:.4f})",
+            f"  α_TG:  {self.alpha_tg:.4f} "
+            f"(95% CI [{self.ci_method}]: {self.ci_low:.4f} - {self.ci_high:.4f})",
             f"  NI_TG: {self.ni_tg:.4f}",
             f"  Divergence:    Dn={self.dn_total}, Ds={self.ds_total}",
             f"  Polymorphism:  Pn={self.pn_total}, Ps={self.ps_total}",
@@ -143,6 +147,7 @@ class AlphaTGResult:
             "omega_a_ci_high": self.omega_a_ci_high,
             "omega_na_ci_low": self.omega_na_ci_low,
             "omega_na_ci_high": self.omega_na_ci_high,
+            "ci_method": self.ci_method,
         }
 
 

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -124,6 +124,10 @@ class AsymptoticMKResult:
     """Adaptive component ``alpha_asymptotic * omega``."""
     omega_na: float | None = None
     """Non-adaptive component ``(1 - alpha_asymptotic) * omega``."""
+    ci_method: str = "monte-carlo"
+    """Method used to compute ``ci_low``/``ci_high``: ``"monte-carlo"`` samples
+    parameters from the curve-fit covariance matrix; ``"bootstrap"`` resamples
+    polymorphisms with replacement and refits per replicate."""
 
     # Dn, Ds, Ln, Ls are constants under the asymptotic Monte Carlo procedure,
     # so omega has no sampling distribution. The CIs on omega_a and omega_na
@@ -164,7 +168,7 @@ class AsymptoticMKResult:
         lines = [
             "Asymptotic MK Test Results:",
             f"  Asymptotic α: {self.alpha_asymptotic:.4f} "
-            f"(95% CI: {self.ci_low:.4f} - {self.ci_high:.4f})",
+            f"(95% CI [{self.ci_method}]: {self.ci_low:.4f} - {self.ci_high:.4f})",
             f"  Divergence: Dn={self.dn}, Ds={self.ds}",
         ]
         if self.pn_total > 0 or self.ps_total > 0:
@@ -232,6 +236,7 @@ class AsymptoticMKResult:
         result["omega_a_ci_high"] = self.omega_a_ci_high
         result["omega_na_ci_low"] = self.omega_na_ci_low
         result["omega_na_ci_high"] = self.omega_na_ci_high
+        result["ci_method"] = self.ci_method
         return result
 
 
@@ -317,6 +322,94 @@ def _compute_ci_monte_carlo(
     ci_low = float(np.percentile(alpha_samples, 2.5))
     ci_high = float(np.percentile(alpha_samples, 97.5))
     return (ci_low, ci_high)
+
+
+def _compute_ci_bootstrap(
+    pooled_polymorphisms: list[tuple[float, str]],
+    dn: int,
+    ds: int,
+    bin_edges: np.ndarray,
+    bin_centers: np.ndarray,
+    num_bins: int,
+    model_func: Callable[..., np.ndarray],
+    p0: list[float],
+    bounds: tuple[list[float], list[float]],
+    frequency_cutoffs: tuple[float, float],
+    point_estimate: float,
+    n_replicates: int = 100,
+    seed: int = 42,
+) -> tuple[float, float]:
+    """Compute CI by case-resampling the pooled polymorphism list.
+
+    Each replicate draws ``len(pooled_polymorphisms)`` indices uniformly with
+    replacement, rebins, recomputes per-bin α(x), refits ``model_func`` on the
+    same model the point estimate selected, and evaluates at x=1. Replicates
+    where the fit fails or fewer than 3 valid bins remain are dropped. If
+    fewer than half of the replicates succeed, the CI degenerates to the
+    point estimate.
+    """
+    n = len(pooled_polymorphisms)
+    if n == 0 or dn == 0 or ds == 0 or n_replicates <= 0:
+        return (point_estimate, point_estimate)
+
+    # Vectorize: precompute frequency and is-N arrays once.
+    freqs = np.fromiter((f for f, _ in pooled_polymorphisms), dtype=float, count=n)
+    is_n = np.fromiter((t == "N" for _, t in pooled_polymorphisms), dtype=bool, count=n)
+
+    # Precompute per-polymorphism bin indices once.
+    bin_idx = np.searchsorted(bin_edges[1:], freqs, side="right")
+    np.clip(bin_idx, 0, num_bins - 1, out=bin_idx)
+
+    rng = np.random.default_rng(seed)
+    low_cut, high_cut = frequency_cutoffs
+    bin_in_window = (bin_centers >= low_cut) & (bin_centers <= high_cut)
+
+    bootstrap_alphas: list[float] = []
+    for _ in range(n_replicates):
+        sample = rng.integers(0, n, size=n)
+        sample_bins = bin_idx[sample]
+        sample_n = is_n[sample]
+        boot_pn = np.bincount(sample_bins[sample_n], minlength=num_bins)
+        boot_ps = np.bincount(sample_bins[~sample_n], minlength=num_bins)
+
+        # Per-bin alpha where boot_ps > 0 and inside the fitting window.
+        valid = (boot_ps > 0) & bin_in_window
+        if valid.sum() < 3:
+            # Fall back to full range if cutoffs are too restrictive (mirror point-estimate path).
+            valid = boot_ps > 0
+            if valid.sum() < 3:
+                continue
+        ratio = (ds / dn) * (boot_pn[valid] / boot_ps[valid])
+        boot_alphas = 1.0 - ratio
+        boot_x = bin_centers[valid]
+
+        try:
+            popt_boot, _ = optimize.curve_fit(
+                model_func,
+                boot_x,
+                boot_alphas,
+                p0=p0,
+                bounds=bounds,
+                maxfev=5000,
+            )
+            alpha_at_1 = float(model_func(np.array([1.0]), *popt_boot)[0])
+            if np.isfinite(alpha_at_1):
+                bootstrap_alphas.append(alpha_at_1)
+        except (RuntimeError, ValueError):
+            continue
+
+    if len(bootstrap_alphas) < n_replicates // 2:
+        logger.debug(
+            "Bootstrap CI: only %d/%d replicates succeeded; falling back to point estimate",
+            len(bootstrap_alphas),
+            n_replicates,
+        )
+        return (point_estimate, point_estimate)
+
+    return (
+        float(np.percentile(bootstrap_alphas, 2.5)),
+        float(np.percentile(bootstrap_alphas, 97.5)),
+    )
 
 
 def _compute_aic(n: int, rss: float, k: int) -> float:
@@ -506,6 +599,8 @@ def asymptotic_mk_test_aggregated(
     num_bins: int = 20,
     ci_replicates: int = 10000,
     frequency_cutoffs: tuple[float, float] = (0.1, 0.9),
+    ci_method: str = "monte-carlo",
+    seed: int = 42,
 ) -> AsymptoticMKResult:
     """Genome-wide asymptotic MK test on aggregated data.
 
@@ -516,12 +611,22 @@ def asymptotic_mk_test_aggregated(
     Args:
         gene_data: List of PolymorphismData from individual genes
         num_bins: Number of frequency bins (default 20)
-        ci_replicates: Number of Monte Carlo replicates for CI (default 10000)
+        ci_replicates: Number of CI replicates. For ``ci_method="monte-carlo"``
+            (default), parameters are sampled from the curve-fit covariance —
+            pass ~10000. For ``ci_method="bootstrap"``, each replicate refits
+            the curve so 100-500 is typical.
         frequency_cutoffs: (low, high) frequency range for fitting (default 0.1-0.9)
+        ci_method: ``"monte-carlo"`` (default, parametric MVN sampling from the
+            curve-fit covariance) or ``"bootstrap"`` (case-resampling of the
+            pooled polymorphism list with replacement, refit per replicate).
+        seed: Random seed for reproducibility (default 42).
 
     Returns:
         AsymptoticMKResult with aggregated analysis
     """
+    if ci_method not in ("monte-carlo", "bootstrap"):
+        raise ValueError(f"ci_method must be 'monte-carlo' or 'bootstrap', got {ci_method!r}")
+
     # Aggregate the data
     agg = aggregate_polymorphism_data(gene_data, num_bins)
 
@@ -567,6 +672,7 @@ def asymptotic_mk_test_aggregated(
             num_genes=agg.num_genes,
             pn_total=pn_total,
             ps_total=ps_total,
+            ci_method=ci_method,
         )
         return _attach_omega(result, agg.ln_total, agg.ls_total)
 
@@ -691,8 +797,45 @@ def asymptotic_mk_test_aggregated(
             num_genes=agg.num_genes,
             pn_total=pn_total,
             ps_total=ps_total,
+            ci_method=ci_method,
         )
         return _attach_omega(result, agg.ln_total, agg.ls_total)
+
+    if ci_method == "bootstrap":
+        # Hold to the model the AIC step selected so the CI is comparable to MC.
+        pooled = [p for g in gene_data for p in g.polymorphisms]
+        if use_exponential:
+            ci_low_exp, ci_high_exp = _compute_ci_bootstrap(
+                pooled,
+                dn,
+                ds,
+                bin_edges,
+                bin_centers,
+                num_bins,
+                _exponential_model,
+                p0_exp,
+                bounds_exp,
+                frequency_cutoffs,
+                exp_alpha,
+                n_replicates=ci_replicates,
+                seed=seed,
+            )
+        else:
+            ci_low_lin, ci_high_lin = _compute_ci_bootstrap(
+                pooled,
+                dn,
+                ds,
+                bin_edges,
+                bin_centers,
+                num_bins,
+                _linear_model,
+                p0_lin,
+                bounds_lin,
+                frequency_cutoffs,
+                lin_alpha,
+                n_replicates=ci_replicates,
+                seed=seed,
+            )
 
     if use_exponential:
         a, b, c = exp_popt
@@ -712,6 +855,7 @@ def asymptotic_mk_test_aggregated(
             model_type="exponential",
             pn_total=pn_total,
             ps_total=ps_total,
+            ci_method=ci_method,
         )
     else:
         a_lin, b_lin = lin_popt
@@ -731,6 +875,7 @@ def asymptotic_mk_test_aggregated(
             model_type="linear",
             pn_total=pn_total,
             ps_total=ps_total,
+            ci_method=ci_method,
         )
     return _attach_omega(result, agg.ln_total, agg.ls_total)
 
@@ -891,6 +1036,7 @@ def asymptotic_mk_test(
             ci_high=simple_alpha or 0.0,
             dn=dn,
             ds=ds,
+            ci_method="bootstrap",
         )
         return _attach_omega(result, ln_total, ls_total)
 
@@ -998,5 +1144,6 @@ def asymptotic_mk_test(
         fit_c=float(c),
         dn=dn,
         ds=ds,
+        ci_method="bootstrap",
     )
     return _attach_omega(result, ln_total, ls_total)

--- a/src/mkado/analysis/imputed.py
+++ b/src/mkado/analysis/imputed.py
@@ -11,10 +11,15 @@ increases power to detect positive selection at the gene level.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+
+import numpy as np
 
 from mkado.analysis.asymptotic import PolymorphismData, sum_site_totals
 from mkado.analysis.statistics import fishers_exact, omega_decomposition
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -67,6 +72,42 @@ class ImputedMKResult:
     """Adaptive rate ``alpha * omega`` with imputed alpha (Gossmann, Keightley & Eyre-Walker 2012)."""
     omega_na: float | None = None
     """Non-adaptive component ``(1 - alpha) * omega``."""
+    alpha_ci_low: float | None = None
+    """Lower 95% bootstrap CI for ``alpha``. ``None`` when ``n_bootstrap=0``."""
+    alpha_ci_high: float | None = None
+    """Upper 95% bootstrap CI for ``alpha``."""
+    ci_method: str | None = None
+    """``"bootstrap"`` when CI was computed, ``None`` when ``n_bootstrap=0``."""
+
+    # omega_a/omega_na CIs are pure arithmetic transforms of the alpha CI scaled
+    # by the (constant) point-estimate omega; mirrors AsymptoticMKResult.
+    @property
+    def omega_a_ci_low(self) -> float | None:
+        """Lower 95% CI for ``omega_a`` = ``alpha_ci_low * omega``."""
+        if self.omega is None or self.alpha_ci_low is None:
+            return None
+        return self.alpha_ci_low * self.omega
+
+    @property
+    def omega_a_ci_high(self) -> float | None:
+        """Upper 95% CI for ``omega_a`` = ``alpha_ci_high * omega``."""
+        if self.omega is None or self.alpha_ci_high is None:
+            return None
+        return self.alpha_ci_high * self.omega
+
+    @property
+    def omega_na_ci_low(self) -> float | None:
+        """Lower 95% CI for ``omega_na`` = ``(1 - alpha_ci_high) * omega`` (flipped)."""
+        if self.omega is None or self.alpha_ci_high is None:
+            return None
+        return (1.0 - self.alpha_ci_high) * self.omega
+
+    @property
+    def omega_na_ci_high(self) -> float | None:
+        """Upper 95% CI for ``omega_na`` = ``(1 - alpha_ci_low) * omega``."""
+        if self.omega is None or self.alpha_ci_low is None:
+            return None
+        return (1.0 - self.alpha_ci_low) * self.omega
 
     def __str__(self) -> str:
         alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "N/A"
@@ -80,6 +121,11 @@ class ImputedMKResult:
             f"  Alpha (α):     {alpha_str}",
             f"  p-value:       {self.p_value:.4g}",
         ]
+        if self.alpha_ci_low is not None and self.alpha_ci_high is not None:
+            lines.append(
+                f"  Alpha 95% CI [{self.ci_method}]: "
+                f"({self.alpha_ci_low:.4f}, {self.alpha_ci_high:.4f})"
+            )
         if self.ln is not None and self.ls is not None:
             lines.append(f"  Sites:         Ln={self.ln:.2f}, Ls={self.ls:.2f}")
         if self.omega is not None:
@@ -89,6 +135,15 @@ class ImputedMKResult:
                 f"  omega:         {self.omega:.4f} "
                 f"(omega_a={omega_a_str}, omega_na={omega_na_str})"
             )
+            if self.omega_a_ci_low is not None and self.omega_a_ci_high is not None:
+                lines.append(
+                    f"    omega_a 95% CI:  ({self.omega_a_ci_low:.4f}, {self.omega_a_ci_high:.4f})"
+                )
+            if self.omega_na_ci_low is not None and self.omega_na_ci_high is not None:
+                lines.append(
+                    f"    omega_na 95% CI: ({self.omega_na_ci_low:.4f}, "
+                    f"{self.omega_na_ci_high:.4f})"
+                )
         if self.d is not None:
             lines.append(f"  DFE fractions: d={self.d:.4f}, b={self.b:.4f}, f={self.f:.4f}")
         return "\n".join(lines)
@@ -110,6 +165,13 @@ class ImputedMKResult:
             "omega": self.omega,
             "omega_a": self.omega_a,
             "omega_na": self.omega_na,
+            "alpha_ci_low": self.alpha_ci_low,
+            "alpha_ci_high": self.alpha_ci_high,
+            "ci_method": self.ci_method,
+            "omega_a_ci_low": self.omega_a_ci_low,
+            "omega_a_ci_high": self.omega_a_ci_high,
+            "omega_na_ci_low": self.omega_na_ci_low,
+            "omega_na_ci_high": self.omega_na_ci_high,
         }
         if self.d is not None:
             result["d"] = self.d
@@ -199,11 +261,58 @@ def _compute_imputed(
     )
 
 
+def _bootstrap_imputed_alpha(
+    polymorphisms: list[tuple[float, str]],
+    dn: int,
+    ds: int,
+    cutoff: float,
+    num_synonymous_sites: float | None,
+    num_nonsynonymous_sites: float | None,
+    n_replicates: int,
+    seed: int,
+) -> tuple[float, float] | None:
+    """Bootstrap CI on imputed alpha by case-resampling the polymorphism list.
+
+    Each replicate draws ``len(polymorphisms)`` indices uniformly with
+    replacement and reruns the imputed MK algorithm. Returns ``None`` if
+    no successful replicate yields a defined alpha.
+    """
+    n = len(polymorphisms)
+    if n == 0 or n_replicates <= 0:
+        return None
+
+    rng = np.random.default_rng(seed)
+    bootstrap_alphas: list[float] = []
+    for _ in range(n_replicates):
+        sample_idx = rng.integers(0, n, size=n)
+        boot = [polymorphisms[i] for i in sample_idx]
+        boot_result = _compute_imputed(
+            boot, dn, ds, cutoff, num_synonymous_sites, num_nonsynonymous_sites
+        )
+        if boot_result.alpha is not None:
+            bootstrap_alphas.append(boot_result.alpha)
+
+    if len(bootstrap_alphas) < n_replicates // 2:
+        logger.debug(
+            "Imputed bootstrap CI: only %d/%d replicates yielded defined alpha; skipping CI",
+            len(bootstrap_alphas),
+            n_replicates,
+        )
+        return None
+
+    return (
+        float(np.percentile(bootstrap_alphas, 2.5)),
+        float(np.percentile(bootstrap_alphas, 97.5)),
+    )
+
+
 def imputed_mk_test(
     gene_data: PolymorphismData,
     cutoff: float = 0.15,
     num_synonymous_sites: float | None = None,
     num_nonsynonymous_sites: float | None = None,
+    n_bootstrap: int = 0,
+    seed: int = 42,
 ) -> ImputedMKResult:
     """Perform the imputed McDonald-Kreitman test on a single gene.
 
@@ -219,13 +328,16 @@ def imputed_mk_test(
         cutoff: DAF cutoff separating low and high frequency (default 0.15)
         num_synonymous_sites: Number of synonymous sites (m0) for DFE fractions
         num_nonsynonymous_sites: Number of nonsynonymous sites (mi) for DFE fractions
+        n_bootstrap: Number of bootstrap replicates for the alpha CI. ``0`` (default)
+            disables CI computation and preserves byte-identical legacy output.
+        seed: Random seed for the bootstrap (default 42).
 
     Returns:
         ImputedMKResult with corrected alpha and optionally DFE fractions
     """
     ls = num_synonymous_sites if num_synonymous_sites is not None else gene_data.ls
     ln = num_nonsynonymous_sites if num_nonsynonymous_sites is not None else gene_data.ln
-    return _compute_imputed(
+    result = _compute_imputed(
         gene_data.polymorphisms,
         gene_data.dn,
         gene_data.ds,
@@ -233,6 +345,21 @@ def imputed_mk_test(
         ls,
         ln,
     )
+    if n_bootstrap > 0:
+        ci = _bootstrap_imputed_alpha(
+            gene_data.polymorphisms,
+            gene_data.dn,
+            gene_data.ds,
+            cutoff,
+            ls,
+            ln,
+            n_bootstrap,
+            seed,
+        )
+        if ci is not None:
+            result.alpha_ci_low, result.alpha_ci_high = ci
+            result.ci_method = "bootstrap"
+    return result
 
 
 def imputed_mk_test_multi(
@@ -240,6 +367,8 @@ def imputed_mk_test_multi(
     cutoff: float = 0.15,
     num_synonymous_sites: float | None = None,
     num_nonsynonymous_sites: float | None = None,
+    n_bootstrap: int = 0,
+    seed: int = 42,
 ) -> ImputedMKResult:
     """Perform the imputed MK test on pooled data from multiple genes.
 
@@ -251,6 +380,9 @@ def imputed_mk_test_multi(
         cutoff: DAF cutoff separating low and high frequency (default 0.15)
         num_synonymous_sites: Number of synonymous sites (m0) for DFE fractions
         num_nonsynonymous_sites: Number of nonsynonymous sites (mi) for DFE fractions
+        n_bootstrap: Number of bootstrap replicates for the alpha CI. ``0`` (default)
+            disables CI computation and preserves byte-identical legacy output.
+        seed: Random seed for the bootstrap (default 42).
 
     Returns:
         ImputedMKResult with corrected alpha from pooled data
@@ -268,7 +400,7 @@ def imputed_mk_test_multi(
     ls = num_synonymous_sites if num_synonymous_sites is not None else ls_agg
     ln = num_nonsynonymous_sites if num_nonsynonymous_sites is not None else ln_agg
 
-    return _compute_imputed(
+    result = _compute_imputed(
         all_polymorphisms,
         dn_total,
         ds_total,
@@ -276,3 +408,18 @@ def imputed_mk_test_multi(
         ls,
         ln,
     )
+    if n_bootstrap > 0:
+        ci = _bootstrap_imputed_alpha(
+            all_polymorphisms,
+            dn_total,
+            ds_total,
+            cutoff,
+            ls,
+            ln,
+            n_bootstrap,
+            seed,
+        )
+        if ci is not None:
+            result.alpha_ci_low, result.alpha_ci_high = ci
+            result.ci_method = "bootstrap"
+    return result

--- a/src/mkado/batch_workers.py
+++ b/src/mkado/batch_workers.py
@@ -72,6 +72,10 @@ class BatchTask:
     code_table: int = 1
     """NCBI genetic code table ID."""
 
+    ci_method: str = "monte-carlo"
+    """CI method for aggregated asymptotic MK ("monte-carlo" or "bootstrap").
+    Ignored for non-aggregated modes."""
+
 
 @dataclass
 class WorkerResult:
@@ -123,9 +127,7 @@ def process_gene(task: BatchTask) -> WorkerResult:
         # Determine mode: combined file or separate files
         if task.ingroup_match is not None:
             # Combined file mode
-            all_seqs = SequenceSet.from_fasta(
-                task.file_path, reading_frame=task.reading_frame
-            )
+            all_seqs = SequenceSet.from_fasta(task.file_path, reading_frame=task.reading_frame)
             ingroup_seqs = all_seqs.filter_by_name(task.ingroup_match)
             outgroup_seqs = all_seqs.filter_by_name(task.outgroup_match)
 
@@ -184,7 +186,9 @@ def process_gene(task: BatchTask) -> WorkerResult:
                     gene_id=gene_id,
                     genetic_code=genetic_code,
                 )
-                result = imputed_mk_test(poly_data, cutoff=task.imputed_cutoff)
+                result = imputed_mk_test(
+                    poly_data, cutoff=task.imputed_cutoff, n_bootstrap=task.bootstrap
+                )
                 return WorkerResult(gene_id=gene_id, result=result)
 
             # Polarized mode
@@ -275,7 +279,9 @@ def process_gene(task: BatchTask) -> WorkerResult:
                     gene_id=gene_id,
                     genetic_code=genetic_code,
                 )
-                result = imputed_mk_test(poly_data, cutoff=task.imputed_cutoff)
+                result = imputed_mk_test(
+                    poly_data, cutoff=task.imputed_cutoff, n_bootstrap=task.bootstrap
+                )
                 return WorkerResult(gene_id=gene_id, result=result)
 
             # Polarized mode

--- a/src/mkado/cli.py
+++ b/src/mkado/cli.py
@@ -61,6 +61,36 @@ OutputOption = Annotated[
     ),
 ]
 
+CIMethodOption = Annotated[
+    str,
+    typer.Option(
+        "--ci-method",
+        help="CI method: 'monte-carlo' (default, parametric MVN sampling) or "
+        "'bootstrap' (case-resampling). Meaningful for --asymptotic --aggregate; "
+        "ignored elsewhere. Imputed CI is enabled automatically when --bootstrap > 0.",
+    ),
+]
+
+
+def validate_ci_method(ci_method: str) -> None:
+    """Reject any ``--ci-method`` value other than the two supported strings."""
+    if ci_method not in ("monte-carlo", "bootstrap"):
+        typer.echo(
+            f"Error: Invalid --ci-method '{ci_method}'. Use 'monte-carlo' or 'bootstrap'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
+def resolve_ci_replicates(bootstrap: int, ci_method: str) -> int:
+    """Map ``--bootstrap`` to ``ci_replicates`` for the chosen CI method.
+
+    MC samples params from a covariance matrix (cheap, ~10000×); bootstrap
+    refits the curve per replicate (expensive, ~100×). The 100× factor matches
+    the cost ratio between the two paths.
+    """
+    return bootstrap * 100 if ci_method == "monte-carlo" else bootstrap
+
 
 def write_output(content: str, output_path: Path | None) -> None:
     """Write formatted result content to a file, or to stdout if no path given.
@@ -335,6 +365,7 @@ def test(
         int,
         typer.Option("--bootstrap", help="Bootstrap replicates for CI (asymptotic)"),
     ] = 100,
+    ci_method: CIMethodOption = "monte-carlo",
     # === Common options ===
     output_format: Annotated[
         str,
@@ -412,6 +443,8 @@ def test(
     if output_format not in ("pretty", "tsv", "json"):
         typer.echo(f"Error: Invalid format '{output_format}'.", err=True)
         raise typer.Exit(1)
+
+    validate_ci_method(ci_method)
 
     # Validate option compatibility
     if use_asymptotic and min_freq > 0.0:
@@ -549,7 +582,7 @@ def test(
                 pool_polymorphisms=pool_polymorphisms,
                 genetic_code=genetic_code,
             )
-            result = imputed_mk_test(poly_data, cutoff=imputed_cutoff)
+            result = imputed_mk_test(poly_data, cutoff=imputed_cutoff, n_bootstrap=bootstrap)
         elif polarize_match:
             outgroup2_seqs = all_seqs.filter_by_name(polarize_match)
             if len(outgroup2_seqs) == 0:
@@ -631,7 +664,7 @@ def test(
                 pool_polymorphisms=pool_polymorphisms,
                 genetic_code=genetic_code,
             )
-            result = imputed_mk_test(poly_data, cutoff=imputed_cutoff)
+            result = imputed_mk_test(poly_data, cutoff=imputed_cutoff, n_bootstrap=bootstrap)
         elif polarize_file:
             result = polarized_mk_test(
                 ingroup=fasta,
@@ -763,6 +796,7 @@ def batch(
         int,
         typer.Option("--bootstrap", help="Bootstrap replicates (asymptotic)"),
     ] = 100,
+    ci_method: CIMethodOption = "monte-carlo",
     freq_cutoffs: Annotated[
         str,
         typer.Option("--freq-cutoffs", help="Frequency range 'low,high' (asymptotic)"),
@@ -857,6 +891,8 @@ def batch(
         mkado batch alignments/ -i "dmel" -o "dsim" -w 8
         mkado batch genes/ --ingroup-pattern "*_in.fa" --outgroup-pattern "*_out.fa"
     """
+    validate_ci_method(ci_method)
+
     if output_format not in ("pretty", "tsv", "json"):
         typer.echo(f"Error: Invalid format '{output_format}'.", err=True)
         raise typer.Exit(1)
@@ -987,6 +1023,7 @@ def batch(
                 or alpha_tg
                 or (use_imputed and aggregate),
                 code_table=code_table_id,
+                ci_method=ci_method,
             )
             for f in alignment_files
         ]
@@ -1003,9 +1040,7 @@ def batch(
             for warning in warnings:
                 typer.echo(warning, err=True)
 
-            gene_data_list: list[PolymorphismData] = _collect_gene_data(
-                worker_results, "alpha-TG"
-            )
+            gene_data_list: list[PolymorphismData] = _collect_gene_data(worker_results, "alpha-TG")
 
             if gene_data_list:
                 result = alpha_tg_from_gene_data(
@@ -1033,11 +1068,13 @@ def batch(
             )
 
             if gene_data_list:
+                ci_replicates = resolve_ci_replicates(bootstrap, ci_method)
                 result = asymptotic_mk_test_aggregated(
                     gene_data=gene_data_list,
                     num_bins=bins,
-                    ci_replicates=bootstrap * 100,
+                    ci_replicates=ci_replicates,
                     frequency_cutoffs=frequency_cutoffs,
+                    ci_method=ci_method,
                 )
                 write_output(format_result(result, fmt), output)
 
@@ -1074,6 +1111,7 @@ def batch(
                 result = imputed_mk_test_multi(
                     gene_data=gene_data_list,
                     cutoff=imputed_cutoff,
+                    n_bootstrap=bootstrap,
                 )
                 write_output(format_result(result, fmt), output)
             else:
@@ -1189,9 +1227,7 @@ def batch(
             for warning in warnings:
                 typer.echo(warning, err=True)
 
-            gene_data_list: list[PolymorphismData] = _collect_gene_data(
-                worker_results, "alpha-TG"
-            )
+            gene_data_list: list[PolymorphismData] = _collect_gene_data(worker_results, "alpha-TG")
 
             if gene_data_list:
                 result = alpha_tg_from_gene_data(
@@ -1219,11 +1255,13 @@ def batch(
             )
 
             if gene_data_list:
+                ci_replicates = resolve_ci_replicates(bootstrap, ci_method)
                 result = asymptotic_mk_test_aggregated(
                     gene_data=gene_data_list,
                     num_bins=bins,
-                    ci_replicates=bootstrap * 100,
+                    ci_replicates=ci_replicates,
                     frequency_cutoffs=frequency_cutoffs,
+                    ci_method=ci_method,
                 )
                 write_output(format_result(result, fmt), output)
 
@@ -1260,6 +1298,7 @@ def batch(
                 result = imputed_mk_test_multi(
                     gene_data=gene_data_list,
                     cutoff=imputed_cutoff,
+                    n_bootstrap=bootstrap,
                 )
                 write_output(format_result(result, fmt), output)
             else:
@@ -1408,6 +1447,7 @@ def vcf(
         int,
         typer.Option("--bootstrap", help="Bootstrap replicates"),
     ] = 100,
+    ci_method: CIMethodOption = "monte-carlo",
     freq_cutoffs: Annotated[
         str,
         typer.Option("--freq-cutoffs", help="Frequency range 'low,high' (asymptotic)"),
@@ -1491,6 +1531,8 @@ def vcf(
     if output_format not in ("pretty", "tsv", "json"):
         typer.echo(f"Error: Invalid format '{output_format}'.", err=True)
         raise typer.Exit(1)
+
+    validate_ci_method(ci_method)
 
     # Validate file existence
     for path, name in [(vcf_file, "--vcf"), (ref, "--ref"), (gff, "--gff")]:
@@ -1603,6 +1645,7 @@ def vcf(
             use_imputed=use_imputed and not aggregate,
             imputed_cutoff=imputed_cutoff,
             extract_only=is_aggregate or (gene is None and not use_asymptotic and not use_imputed),
+            ci_method=ci_method,
         )
         for cds in cds_regions
     ]
@@ -1640,8 +1683,7 @@ def vcf(
         # VCF/FASTA handles only once and reuses them for all its genes.
         chunk_size = math.ceil(len(tasks) / num_workers)
         chunks = [
-            VcfBatchChunk(tasks=tasks[i : i + chunk_size])
-            for i in range(0, len(tasks), chunk_size)
+            VcfBatchChunk(tasks=tasks[i : i + chunk_size]) for i in range(0, len(tasks), chunk_size)
         ]
 
         with ProcessPoolExecutor(max_workers=num_workers) as executor:
@@ -1681,9 +1723,7 @@ def vcf(
         from mkado.analysis.alpha_tg import alpha_tg_from_gene_data
         from mkado.analysis.asymptotic import PolymorphismData
 
-        gene_data_list: list[PolymorphismData] = _collect_gene_data(
-            worker_results, "alpha-TG"
-        )
+        gene_data_list: list[PolymorphismData] = _collect_gene_data(worker_results, "alpha-TG")
         if gene_data_list:
             result = alpha_tg_from_gene_data(
                 gene_data=gene_data_list,
@@ -1700,11 +1740,13 @@ def vcf(
 
         gene_data_list = _collect_gene_data(worker_results, "aggregated asymptotic")
         if gene_data_list:
+            ci_replicates = resolve_ci_replicates(bootstrap, ci_method)
             result = asymptotic_mk_test_aggregated(
                 gene_data=gene_data_list,
                 num_bins=bins,
-                ci_replicates=bootstrap * 100,
+                ci_replicates=ci_replicates,
                 frequency_cutoffs=frequency_cutoffs,
+                ci_method=ci_method,
             )
             write_output(format_result(result, fmt), output)
             if plot_asymptotic:
@@ -1729,6 +1771,7 @@ def vcf(
             result = imputed_mk_test_multi(
                 gene_data=gene_data_list,
                 cutoff=imputed_cutoff,
+                n_bootstrap=bootstrap,
             )
             write_output(format_result(result, fmt), output)
         else:

--- a/src/mkado/io/output.py
+++ b/src/mkado/io/output.py
@@ -93,15 +93,22 @@ def _format_tsv(
 
     if isinstance(result, ImputedMKResult):
         alpha_str = f"{result.alpha:.6f}" if result.alpha is not None else "NA"
+        ci_method_str = result.ci_method if result.ci_method is not None else "NA"
         header = (
             "Dn\tDs\tPn\tPs\tPwd\tPn_neutral\talpha\tp_value\tcutoff\t"
-            "Ln\tLs\tomega\tomega_a\tomega_na"
+            "Ln\tLs\tomega\tomega_a\tomega_na\t"
+            "alpha_CI_low\talpha_CI_high\t"
+            "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
         )
         values = (
             f"{result.dn}\t{result.ds}\t{result.pn_total}\t{result.ps_total}\t"
             f"{result.pwd:.2f}\t{result.pn_neutral:.2f}\t{alpha_str}\t"
             f"{result.p_value:.6g}\t{result.cutoff}\t"
-            f"{_omega_full_tsv_columns(result)}"
+            f"{_omega_full_tsv_columns(result)}\t"
+            f"{_fmt_optional(result.alpha_ci_low)}\t{_fmt_optional(result.alpha_ci_high)}\t"
+            f"{_fmt_optional(result.omega_a_ci_low)}\t{_fmt_optional(result.omega_a_ci_high)}\t"
+            f"{_fmt_optional(result.omega_na_ci_low)}\t{_fmt_optional(result.omega_na_ci_high)}\t"
+            f"{ci_method_str}"
         )
         return f"{header}\n{values}"
 
@@ -143,7 +150,7 @@ def _format_tsv(
         return "\n".join(lines)
 
     elif isinstance(result, AsymptoticMKResult):
-        ci_cols = "\tomega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
+        ci_cols = "\tomega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
         if result.num_genes > 0:
             # Aggregated result
             header = (
@@ -155,7 +162,7 @@ def _format_tsv(
                 f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
                 f"{result.model_type}\t{result.num_genes}\t"
                 f"{_omega_full_tsv_columns(result)}\t"
-                f"{_omega_a_na_ci_tsv_columns(result)}"
+                f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
             )
         else:
             header = (
@@ -166,7 +173,7 @@ def _format_tsv(
                 f"{result.dn}\t{result.ds}\t{result.alpha_asymptotic:.6f}\t"
                 f"{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
                 f"{_omega_full_tsv_columns(result)}\t"
-                f"{_omega_a_na_ci_tsv_columns(result)}"
+                f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
             )
         return f"{header}\n{values}"
 
@@ -175,7 +182,7 @@ def _format_tsv(
             "Dn\tDs\tPn\tPs\talpha_TG\tNI_TG\tCI_low\tCI_high\tnum_genes\t"
             "Ln\tLs\tomega\tomega_a\tomega_na\t"
             "omega_CI_low\tomega_CI_high\t"
-            "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
+            "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
         )
         values = (
             f"{result.dn_total}\t{result.ds_total}\t{result.pn_total}\t{result.ps_total}\t"
@@ -183,7 +190,7 @@ def _format_tsv(
             f"{result.num_genes}\t"
             f"{_omega_full_tsv_columns(result)}\t"
             f"{_fmt_optional(result.omega_ci_low)}\t{_fmt_optional(result.omega_ci_high)}\t"
-            f"{_omega_a_na_ci_tsv_columns(result)}"
+            f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
         )
         return f"{header}\n{values}"
 
@@ -263,7 +270,7 @@ def format_batch_results(
             header = (
                 "gene\tDn\tDs\talpha_asymptotic\tCI_low\tCI_high\tmodel\t"
                 "Ln\tLs\tomega\tomega_a\tomega_na\t"
-                "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
+                "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
             )
             lines = [header]
             for name, result in results:
@@ -273,7 +280,7 @@ def format_batch_results(
                         f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t"
                         f"{result.ci_high:.6f}\t{result.model_type}\t"
                         f"{_omega_full_tsv_columns(result)}\t"
-                        f"{_omega_a_na_ci_tsv_columns(result)}"
+                        f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
                     )
             return "\n".join(lines)
 

--- a/src/mkado/io/plotting.py
+++ b/src/mkado/io/plotting.py
@@ -120,8 +120,7 @@ def create_volcano_plot(
     sig_fdr = (p_arr < fdr_threshold) & ~sig_bonf
     colors = np.where(sig_bonf, "#e74c3c", np.where(sig_fdr, "#e67e22", "#3498db"))
 
-    # Create scatter plot
-    scatter = ax.scatter(
+    ax.scatter(
         neg_log10_ni,
         neg_log10_p,
         c=colors,
@@ -259,10 +258,10 @@ def create_asymptotic_plot(
     x_curve = np.linspace(0.05, 1.0, 100)
     if result.model_type == "exponential":
         y_curve = result.fit_a + result.fit_b * np.exp(-result.fit_c * x_curve)
-        fit_label = f"Fit: a + b·e$^{{-cx}}$"
+        fit_label = "Fit: a + b·e$^{-cx}$"
     else:
         y_curve = result.fit_a + result.fit_b * x_curve
-        fit_label = f"Fit: a + b·x"
+        fit_label = "Fit: a + b·x"
 
     ax.plot(
         x_curve,

--- a/src/mkado/vcf_workers.py
+++ b/src/mkado/vcf_workers.py
@@ -37,6 +37,7 @@ class VcfBatchTask:
     use_imputed: bool = False
     imputed_cutoff: float = 0.15
     extract_only: bool = False
+    ci_method: str = "monte-carlo"
 
 
 @dataclass
@@ -109,10 +110,16 @@ def _process_single_gene(
         if task.use_asymptotic:
             from mkado.analysis.asymptotic import asymptotic_mk_test_aggregated
 
+            # MC samples params from a covariance matrix (cheap, ~10000×); bootstrap
+            # refits the curve per replicate (expensive, ~100×) — hence the 100× factor.
+            ci_replicates = (
+                task.bootstrap * 100 if task.ci_method == "monte-carlo" else task.bootstrap
+            )
             result = asymptotic_mk_test_aggregated(
                 gene_data=[poly_data],
                 num_bins=task.bins,
-                ci_replicates=task.bootstrap * 100,
+                ci_replicates=ci_replicates,
+                ci_method=task.ci_method,
             )
             return WorkerResult(gene_id=task.gene_id, result=result, warning=warning)
 
@@ -120,7 +127,9 @@ def _process_single_gene(
         if task.use_imputed:
             from mkado.analysis.imputed import imputed_mk_test
 
-            result = imputed_mk_test(poly_data, cutoff=task.imputed_cutoff)
+            result = imputed_mk_test(
+                poly_data, cutoff=task.imputed_cutoff, n_bootstrap=task.bootstrap
+            )
             return WorkerResult(gene_id=task.gene_id, result=result, warning=warning)
 
         # Standard MK from counts
@@ -233,10 +242,16 @@ def process_vcf_gene(task: VcfBatchTask) -> WorkerResult:
         if task.use_asymptotic:
             from mkado.analysis.asymptotic import asymptotic_mk_test_aggregated
 
+            # MC samples params from a covariance matrix (cheap, ~10000×); bootstrap
+            # refits the curve per replicate (expensive, ~100×) — hence the 100× factor.
+            ci_replicates = (
+                task.bootstrap * 100 if task.ci_method == "monte-carlo" else task.bootstrap
+            )
             result = asymptotic_mk_test_aggregated(
                 gene_data=[poly_data],
                 num_bins=task.bins,
-                ci_replicates=task.bootstrap * 100,
+                ci_replicates=ci_replicates,
+                ci_method=task.ci_method,
             )
             return WorkerResult(gene_id=task.gene_id, result=result, warning=warning)
 
@@ -244,7 +259,9 @@ def process_vcf_gene(task: VcfBatchTask) -> WorkerResult:
         if task.use_imputed:
             from mkado.analysis.imputed import imputed_mk_test
 
-            result = imputed_mk_test(poly_data, cutoff=task.imputed_cutoff)
+            result = imputed_mk_test(
+                poly_data, cutoff=task.imputed_cutoff, n_bootstrap=task.bootstrap
+            )
             return WorkerResult(gene_id=task.gene_id, result=result, warning=warning)
 
         # Standard MK from counts

--- a/tests/test_asymptotic.py
+++ b/tests/test_asymptotic.py
@@ -321,9 +321,7 @@ class TestMonteCarloCi:
         popt = np.array([0.1, 0.8])
         pcov = np.array([[0.001, 0.0], [0.0, 0.001]])
 
-        ci_low, ci_high = _compute_ci_monte_carlo(
-            popt, pcov, _linear_model, n_sim=5000
-        )
+        ci_low, ci_high = _compute_ci_monte_carlo(popt, pcov, _linear_model, n_sim=5000)
 
         # CI should bracket the point estimate at x=1
         alpha_at_1 = 0.1 + 0.8  # = 0.9
@@ -336,15 +334,15 @@ class TestMonteCarloCi:
         # Model: α(x) = a + b * exp(-c * x)
         # For typical positive selection signal, b is negative (alpha increases with x)
         popt = np.array([0.5, -0.3, 2.0])
-        pcov = np.array([
-            [0.001, 0.0, 0.0],
-            [0.0, 0.001, 0.0],
-            [0.0, 0.0, 0.01],
-        ])
-
-        ci_low, ci_high = _compute_ci_monte_carlo(
-            popt, pcov, _exponential_model, n_sim=5000
+        pcov = np.array(
+            [
+                [0.001, 0.0, 0.0],
+                [0.0, 0.001, 0.0],
+                [0.0, 0.0, 0.01],
+            ]
         )
+
+        ci_low, ci_high = _compute_ci_monte_carlo(popt, pcov, _exponential_model, n_sim=5000)
 
         # CI should bracket the point estimate
         # α(1) = a + b * exp(-c) = 0.5 + (-0.3) * exp(-2.0)
@@ -393,9 +391,7 @@ class TestAsymptoticMKTestAggregated:
         if not ingroup.exists() or not outgroup.exists():
             pytest.skip("Test data files not found")
 
-        gene_data = [
-            extract_polymorphism_data(ingroup, outgroup, gene_id="adh")
-        ]
+        gene_data = [extract_polymorphism_data(ingroup, outgroup, gene_id="adh")]
 
         result = asymptotic_mk_test_aggregated(gene_data, num_bins=5)
 
@@ -444,3 +440,179 @@ class TestAsymptoticMKTestAggregated:
         assert d["ps_total"] == 800
         assert d["model_type"] == "linear"
         assert "c" not in d["fit_parameters"]  # Linear model has no c
+
+
+def _make_aggregated_gene_data(
+    num_genes: int = 10,
+    dn_per_gene: int = 10,
+    ds_per_gene: int = 15,
+    seed: int = 0,
+) -> list[PolymorphismData]:
+    """Build a deterministic but signal-bearing fixture for the aggregated test."""
+    rng = np.random.default_rng(seed)
+    gene_data = []
+    for i in range(num_genes):
+        poly: list[tuple[float, str]] = []
+        # Spread polymorphisms across the SFS so the curve fit converges.
+        for freq in [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]:
+            n_pn = int(rng.integers(1, 5))
+            n_ps = int(rng.integers(2, 7))
+            poly.extend([(freq, "N")] * n_pn)
+            poly.extend([(freq, "S")] * n_ps)
+        gene_data.append(
+            PolymorphismData(
+                polymorphisms=poly,
+                dn=dn_per_gene,
+                ds=ds_per_gene,
+                gene_id=f"gene{i}",
+                ln=300.0,
+                ls=100.0,
+            )
+        )
+    return gene_data
+
+
+class TestBootstrapCi:
+    """Tests for the multinomial-style bootstrap CI on asymptotic_mk_test_aggregated."""
+
+    def test_ci_method_default_is_monte_carlo(self) -> None:
+        """Default CI method preserves existing behavior."""
+        gene_data = _make_aggregated_gene_data(num_genes=15, seed=1)
+        result = asymptotic_mk_test_aggregated(gene_data, num_bins=10)
+        assert result.ci_method == "monte-carlo"
+
+    def test_ci_method_bootstrap_sets_field(self) -> None:
+        """ci_method='bootstrap' is recorded on the result."""
+        gene_data = _make_aggregated_gene_data(num_genes=15, seed=2)
+        result = asymptotic_mk_test_aggregated(
+            gene_data, num_bins=10, ci_method="bootstrap", ci_replicates=100, seed=42
+        )
+        assert result.ci_method == "bootstrap"
+
+    def test_bootstrap_brackets_point_estimate(self) -> None:
+        """Bootstrap CI should bracket alpha_asymptotic for well-behaved data."""
+        gene_data = _make_aggregated_gene_data(num_genes=30, seed=3)
+        result = asymptotic_mk_test_aggregated(
+            gene_data, num_bins=10, ci_method="bootstrap", ci_replicates=200, seed=42
+        )
+        # CI may be wide on small synthetic data, but it should bracket the point estimate.
+        assert result.ci_low <= result.alpha_asymptotic <= result.ci_high
+
+    def test_bootstrap_reproducibility_with_seed(self) -> None:
+        """Same seed → same CI."""
+        gene_data = _make_aggregated_gene_data(num_genes=15, seed=4)
+        r1 = asymptotic_mk_test_aggregated(
+            gene_data, num_bins=10, ci_method="bootstrap", ci_replicates=100, seed=42
+        )
+        r2 = asymptotic_mk_test_aggregated(
+            gene_data, num_bins=10, ci_method="bootstrap", ci_replicates=100, seed=42
+        )
+        assert r1.ci_low == r2.ci_low
+        assert r1.ci_high == r2.ci_high
+
+    def test_bootstrap_zero_count_bin_does_not_crash(self) -> None:
+        """Sparse fixture with empty bins should produce a valid result, not crash."""
+        # Polymorphisms only at three frequencies → most bins are empty
+        sparse_gene = PolymorphismData(
+            polymorphisms=[(0.2, "N")] * 3
+            + [(0.5, "N")] * 4
+            + [(0.8, "N")] * 2
+            + [(0.2, "S")] * 6
+            + [(0.5, "S")] * 8
+            + [(0.8, "S")] * 4,
+            dn=10,
+            ds=15,
+            gene_id="sparse",
+            ln=300.0,
+            ls=100.0,
+        )
+        result = asymptotic_mk_test_aggregated(
+            [sparse_gene] * 5,
+            num_bins=20,
+            ci_method="bootstrap",
+            ci_replicates=50,
+            seed=42,
+        )
+        # Should produce some result; CI may degenerate to point estimate but must not crash.
+        assert isinstance(result, AsymptoticMKResult)
+        assert result.ci_method == "bootstrap"
+
+    def test_bootstrap_invalid_method_rejected(self) -> None:
+        """Unknown ci_method should raise."""
+        gene_data = _make_aggregated_gene_data(num_genes=10, seed=5)
+        with pytest.raises(ValueError, match="ci_method"):
+            asymptotic_mk_test_aggregated(gene_data, num_bins=10, ci_method="bogus")
+
+    def test_bootstrap_to_dict_includes_ci_method(self) -> None:
+        """ci_method appears in to_dict() output."""
+        gene_data = _make_aggregated_gene_data(num_genes=15, seed=6)
+        result = asymptotic_mk_test_aggregated(
+            gene_data, num_bins=10, ci_method="bootstrap", ci_replicates=50, seed=42
+        )
+        assert result.to_dict()["ci_method"] == "bootstrap"
+
+
+class TestBootstrapCiCoverage:
+    """Synthetic-coverage acceptance test (replaces issue's 'human dataset' criterion)."""
+
+    @pytest.mark.slow
+    def test_coverage_approx_nominal(self) -> None:
+        """Across many trials simulating data from a known α(x), the 95% CI should cover the truth most of the time.
+
+        This is a stochastic test; we only require coverage between 0.7 and 1.0
+        rather than exactly 0.95, since the bootstrap is approximate and we can
+        only afford ~50 trials in CI runtime.
+        """
+        true_a, true_b, true_c = 0.5, -0.4, 3.0
+        true_alpha_at_1 = true_a + true_b * np.exp(-true_c)
+        n_trials = 50
+        n_replicates = 100
+        master_rng = np.random.default_rng(2026)
+        n_inside = 0
+
+        for trial in range(n_trials):
+            sim_seed = int(master_rng.integers(0, 2**31 - 1))
+            sim_rng = np.random.default_rng(sim_seed)
+            # Simulate per-bin Pn/Ps under the model: alpha(x) = a + b*exp(-c*x)
+            # implies Pn(x)/Ps(x) = (1 - alpha(x)) * Dn/Ds. We fix Dn, Ds and totals.
+            num_bins = 10
+            bin_centers = (np.arange(num_bins) + 0.5) / num_bins
+            dn_total = 200
+            ds_total = 400
+            ps_per_bin = 30
+            gene_polys: list[tuple[float, str]] = []
+            for x, alpha_x in zip(bin_centers, true_a + true_b * np.exp(-true_c * bin_centers)):
+                # Expected ratio Pn/Ps at this bin
+                ratio = (1.0 - alpha_x) * dn_total / ds_total
+                expected_pn = ps_per_bin * ratio
+                pn_count = int(sim_rng.poisson(max(expected_pn, 0.0)))
+                gene_polys.extend([(float(x), "N")] * pn_count)
+                gene_polys.extend([(float(x), "S")] * ps_per_bin)
+
+            gene = PolymorphismData(
+                polymorphisms=gene_polys,
+                dn=dn_total,
+                ds=ds_total,
+                gene_id=f"sim{trial}",
+                ln=600.0,
+                ls=200.0,
+            )
+            try:
+                result = asymptotic_mk_test_aggregated(
+                    [gene],
+                    num_bins=num_bins,
+                    ci_method="bootstrap",
+                    ci_replicates=n_replicates,
+                    seed=sim_seed,
+                )
+            except (RuntimeError, ValueError):
+                continue
+            if result.ci_low <= true_alpha_at_1 <= result.ci_high:
+                n_inside += 1
+
+        coverage = n_inside / n_trials
+        # Loose check — bootstrap is approximate and the simulation has its own noise.
+        assert 0.7 <= coverage <= 1.0, (
+            f"Bootstrap CI coverage {coverage:.2f} outside expected range; "
+            f"true α(1)={true_alpha_at_1:.4f}"
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,3 +410,64 @@ ATGGTGATG
         )
         assert result.exit_code == 1
         assert "Unknown genetic code" in result.output
+
+
+class TestCiMethodOption:
+    """Tests for --ci-method flag."""
+
+    def _make_alignment_dir(self, tmp_path: Path) -> Path:
+        """Build a tiny multi-gene alignment dir suitable for batch -a."""
+        alignment_dir = tmp_path / "alignments"
+        alignment_dir.mkdir()
+        # Three genes; each has a couple of polymorphisms across frequency
+        for i, codons in enumerate(["ATGTTT", "ATGTTC", "ATGTTA"]):
+            fa = alignment_dir / f"gene{i}.fa"
+            fa.write_text(
+                f">speciesA_1\n{codons}\n>speciesA_2\nATG{codons[3:]}\n"
+                f">speciesA_3\n{codons}\n>speciesB_1\nATGTTG\n"
+            )
+        return alignment_dir
+
+    def test_invalid_ci_method_rejected_in_test(self, tmp_path: Path) -> None:
+        fasta = tmp_path / "test.fa"
+        fasta.write_text(">speciesA_1\nATGATGATG\n>speciesB_1\nATGGTGATG\n")
+        result = runner.invoke(
+            app,
+            ["test", str(fasta), "-i", "speciesA", "-o", "speciesB", "--ci-method", "bogus"],
+        )
+        assert result.exit_code == 1
+        assert "Invalid --ci-method" in result.output
+
+    def test_invalid_ci_method_rejected_in_batch(self, tmp_path: Path) -> None:
+        alignment_dir = self._make_alignment_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            ["batch", str(alignment_dir), "-i", "speciesA", "-o", "speciesB",
+             "--ci-method", "bogus"],
+        )
+        assert result.exit_code == 1
+        assert "Invalid --ci-method" in result.output
+
+    def test_ci_method_default_is_monte_carlo_in_tsv(self, tmp_path: Path) -> None:
+        """Default --ci-method should produce ci_method=monte-carlo in batch -a output."""
+        alignment_dir = self._make_alignment_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            ["batch", str(alignment_dir), "-i", "speciesA", "-o", "speciesB",
+             "--asymptotic", "--format", "tsv"],
+        )
+        assert result.exit_code == 0
+        assert "ci_method" in result.output
+        assert "monte-carlo" in result.output
+
+    def test_ci_method_bootstrap_appears_in_tsv(self, tmp_path: Path) -> None:
+        alignment_dir = self._make_alignment_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            ["batch", str(alignment_dir), "-i", "speciesA", "-o", "speciesB",
+             "--asymptotic", "--ci-method", "bootstrap", "--bootstrap", "20",
+             "--format", "tsv"],
+        )
+        assert result.exit_code == 0
+        assert "ci_method" in result.output
+        assert "bootstrap" in result.output

--- a/tests/test_imputed.py
+++ b/tests/test_imputed.py
@@ -69,17 +69,15 @@ class TestImputedMKTest:
         """Verify d + b + f sums to 1 - alpha when m0/mi provided."""
         gene = PolymorphismData(
             polymorphisms=(
-                [(0.05, "N")] * 5
-                + [(0.50, "N")] * 5
-                + [(0.10, "S")] * 4
-                + [(0.50, "S")] * 8
+                [(0.05, "N")] * 5 + [(0.50, "N")] * 5 + [(0.10, "S")] * 4 + [(0.50, "S")] * 8
             ),
             dn=10,
             ds=6,
         )
 
-        result = imputed_mk_test(gene, cutoff=0.15, num_synonymous_sites=100.0,
-                                 num_nonsynonymous_sites=300.0)
+        result = imputed_mk_test(
+            gene, cutoff=0.15, num_synonymous_sites=100.0, num_nonsynonymous_sites=300.0
+        )
 
         assert result.d is not None
         assert result.b is not None
@@ -106,9 +104,7 @@ class TestImputedMKTest:
         """Edge case: all synonymous polymorphisms are low-frequency."""
         gene = PolymorphismData(
             polymorphisms=(
-                [(0.05, "N")] * 3
-                + [(0.50, "N")] * 2
-                + [(0.10, "S")] * 4  # all below cutoff
+                [(0.05, "N")] * 3 + [(0.50, "N")] * 2 + [(0.10, "S")] * 4  # all below cutoff
             ),
             dn=5,
             ds=3,
@@ -123,10 +119,7 @@ class TestImputedMKTest:
     def test_all_polymorphisms_above_cutoff(self) -> None:
         """When all polymorphisms are high-frequency, pwd should be 0."""
         gene = PolymorphismData(
-            polymorphisms=(
-                [(0.50, "N")] * 4
-                + [(0.60, "S")] * 5
-            ),
+            polymorphisms=([(0.50, "N")] * 4 + [(0.60, "S")] * 5),
             dn=6,
             ds=4,
         )
@@ -213,20 +206,14 @@ class TestImputedMKTestMulti:
         """Verify pooled results match manually aggregated data."""
         gene1 = PolymorphismData(
             polymorphisms=(
-                [(0.05, "N")] * 3
-                + [(0.50, "N")] * 2
-                + [(0.10, "S")] * 2
-                + [(0.40, "S")] * 4
+                [(0.05, "N")] * 3 + [(0.50, "N")] * 2 + [(0.10, "S")] * 2 + [(0.40, "S")] * 4
             ),
             dn=5,
             ds=3,
         )
         gene2 = PolymorphismData(
             polymorphisms=(
-                [(0.08, "N")] * 2
-                + [(0.60, "N")] * 3
-                + [(0.12, "S")] * 1
-                + [(0.50, "S")] * 3
+                [(0.08, "N")] * 2 + [(0.60, "N")] * 3 + [(0.12, "S")] * 1 + [(0.50, "S")] * 3
             ),
             dn=4,
             ds=2,
@@ -381,13 +368,15 @@ class TestImputedMKResult:
 
         assert (
             "Dn\tDs\tPn\tPs\tPwd\tPn_neutral\talpha\tp_value\tcutoff\t"
-            "Ln\tLs\tomega\tomega_a\tomega_na"
+            "Ln\tLs\tomega\tomega_a\tomega_na\t"
+            "alpha_CI_low\talpha_CI_high\t"
+            "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
         ) == header
         fields = values.split("\t")
-        assert fields[0] == "7"   # Dn
-        assert fields[1] == "5"   # Ds
+        assert fields[0] == "7"  # Dn
+        assert fields[1] == "5"  # Ds
         assert fields[2] == "10"  # Pn
-        assert fields[3] == "9"   # Ps
+        assert fields[3] == "9"  # Ps
         assert fields[4] == "4.00"  # Pwd
         assert fields[5] == "6.00"  # Pn_neutral
         assert fields[6] == "0.520000"  # alpha
@@ -415,3 +404,114 @@ class TestImputedMKIntegration:
         assert result.pwd >= 0
         assert result.pn_neutral >= 0
         assert result.cutoff == 0.15
+
+
+def _imputed_fixture() -> PolymorphismData:
+    """Fixture with both low- and high-frequency polymorphisms for imputed bootstrap."""
+    return PolymorphismData(
+        polymorphisms=(
+            [(0.05, "N")] * 7 + [(0.50, "N")] * 4 + [(0.10, "S")] * 6 + [(0.50, "S")] * 11
+        ),
+        dn=10,
+        ds=8,
+        ln=300.0,
+        ls=100.0,
+    )
+
+
+class TestImputedBootstrapCi:
+    """Tests for the bootstrap CI on imputed_mk_test."""
+
+    def test_n_bootstrap_zero_preserves_legacy_output(self) -> None:
+        """n_bootstrap=0 (default) leaves CI fields None and preserves point estimates."""
+        gene = _imputed_fixture()
+        legacy = imputed_mk_test(gene, cutoff=0.15)
+        with_arg = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=0)
+
+        # Point estimates byte-identical
+        assert legacy.alpha == with_arg.alpha
+        assert legacy.pwd == with_arg.pwd
+        assert legacy.pn_neutral == with_arg.pn_neutral
+        # No CI fields populated
+        assert legacy.alpha_ci_low is None
+        assert legacy.alpha_ci_high is None
+        assert legacy.ci_method is None
+        assert with_arg.alpha_ci_low is None
+        assert with_arg.ci_method is None
+
+    def test_bootstrap_populates_ci_fields(self) -> None:
+        gene = _imputed_fixture()
+        result = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=200, seed=42)
+        assert result.alpha_ci_low is not None
+        assert result.alpha_ci_high is not None
+        assert result.alpha_ci_low <= result.alpha_ci_high
+        assert result.ci_method == "bootstrap"
+
+    def test_bootstrap_brackets_alpha(self) -> None:
+        """Bootstrap CI should bracket the point estimate."""
+        gene = _imputed_fixture()
+        result = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=500, seed=42)
+        assert result.alpha is not None
+        assert result.alpha_ci_low <= result.alpha <= result.alpha_ci_high
+
+    def test_bootstrap_reproducibility_with_seed(self) -> None:
+        gene = _imputed_fixture()
+        r1 = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=100, seed=42)
+        r2 = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=100, seed=42)
+        assert r1.alpha_ci_low == r2.alpha_ci_low
+        assert r1.alpha_ci_high == r2.alpha_ci_high
+
+    def test_bootstrap_to_dict_includes_ci_fields(self) -> None:
+        gene = _imputed_fixture()
+        result = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=100, seed=42)
+        d = result.to_dict()
+        assert "alpha_ci_low" in d
+        assert "alpha_ci_high" in d
+        assert "ci_method" in d
+        assert d["ci_method"] == "bootstrap"
+
+    def test_bootstrap_omega_a_ci_derived_from_alpha_ci(self) -> None:
+        """omega_a/omega_na CI should be the alpha CI scaled by omega (mirrors AsymptoticMKResult)."""
+        gene = _imputed_fixture()
+        result = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=100, seed=42)
+        assert result.omega is not None
+        assert result.omega_a_ci_low is not None
+        # omega_a_ci_low = alpha_ci_low * omega
+        assert result.omega_a_ci_low == pytest.approx(result.alpha_ci_low * result.omega)
+        assert result.omega_a_ci_high == pytest.approx(result.alpha_ci_high * result.omega)
+        # omega_na percentiles flip: omega_na_ci_low uses (1 - alpha_ci_high)
+        assert result.omega_na_ci_low == pytest.approx((1.0 - result.alpha_ci_high) * result.omega)
+        assert result.omega_na_ci_high == pytest.approx((1.0 - result.alpha_ci_low) * result.omega)
+
+    def test_multi_n_bootstrap_zero_preserves_legacy(self) -> None:
+        """imputed_mk_test_multi with n_bootstrap=0 preserves legacy behavior."""
+        gene1 = _imputed_fixture()
+        gene2 = PolymorphismData(
+            polymorphisms=[(0.05, "N")] * 3 + [(0.4, "S")] * 5,
+            dn=4,
+            ds=3,
+            ln=200.0,
+            ls=70.0,
+        )
+        legacy = imputed_mk_test_multi([gene1, gene2], cutoff=0.15)
+        with_arg = imputed_mk_test_multi([gene1, gene2], cutoff=0.15, n_bootstrap=0)
+        assert legacy.alpha == with_arg.alpha
+        assert legacy.alpha_ci_low is None
+        assert with_arg.alpha_ci_low is None
+
+    def test_multi_bootstrap_populates_ci(self) -> None:
+        gene1 = _imputed_fixture()
+        gene2 = PolymorphismData(
+            polymorphisms=[(0.05, "N")] * 3
+            + [(0.5, "N")] * 2
+            + [(0.4, "S")] * 5
+            + [(0.5, "S")] * 3,
+            dn=4,
+            ds=3,
+            ln=200.0,
+            ls=70.0,
+        )
+        result = imputed_mk_test_multi([gene1, gene2], cutoff=0.15, n_bootstrap=200, seed=42)
+        assert result.alpha_ci_low is not None
+        assert result.alpha_ci_high is not None
+        assert result.ci_method == "bootstrap"


### PR DESCRIPTION
## Summary

Closes #10 (reviewer point 5(ii) on adding a bootstrap CI alternative to the parametric Monte Carlo).

- Adds a case-resampling bootstrap to \`asymptotic_mk_test_aggregated\` and to \`imputed_mk_test\` / \`_multi\`.
- Exposes via \`--ci-method {monte-carlo,bootstrap}\` on \`test\`/\`batch\`/\`vcf\` commands. Default remains \`monte-carlo\` to preserve existing behavior.
- Records the method used on each result type via a new \`ci_method\` field (\`AsymptoticMKResult\`, \`AlphaTGResult\`, \`ImputedMKResult\`); surfaced in pretty / TSV / JSON output.
- Imputed CI is opt-in via the existing \`--bootstrap N\` flag (\`n_bootstrap=0\` default preserves byte-identical legacy output).

## Sanity check (400-gene Anopheles batch)

| | α_asymptotic | 95% CI | Runtime |
|---|---|---|---|
| \`--ci-method monte-carlo\` (default) | 0.577 | [0.497, 0.659] | 2.48 s |
| \`--ci-method bootstrap\` | 0.560 | [0.467, 0.642] | 2.48 s |

CIs in the same ballpark; runtime essentially identical (MC does 10000 cheap MVN draws; bootstrap does 100 curve refits — \`resolve_ci_replicates()\` scales the user-supplied \`--bootstrap\` count appropriately).

## Implementation notes

- **\`_compute_ci_bootstrap\`** (asymptotic.py) resamples the pooled polymorphism list with replacement, rebins via \`np.bincount\`, refits the curve **held to the model the AIC step selected** (so the CI is comparable to the MC version), evaluates at x=1, takes 2.5/97.5 percentiles. Failed replicates are dropped; falls back to the point estimate when fewer than half succeed.
- **\`_bootstrap_imputed_alpha\`** (imputed.py) does the same thing for the imputed test by resampling the polymorphism list and re-running \`_compute_imputed\` per replicate.
- **\`omega_a\` / \`omega_na\` CIs on \`ImputedMKResult\`** are \`@property\` derivations scaling the alpha CI by omega — mirrors the existing \`AsymptoticMKResult\` pattern.
- **\`AlphaTGResult.ci_method\`** is always \`\"bootstrap\"\` (the weighted estimator has no parametric MC analog); the global flag is silently accepted for it.
- **CLI plumbing**: hoisted \`CIMethodOption\` constant + \`validate_ci_method()\` helper + \`resolve_ci_replicates()\` helper to centralize logic across \`test\`/\`batch\`/\`vcf\` commands.

## Coverage acceptance test

The issue's \"compare on the human dataset\" criterion is replaced with a synthetic-coverage test (\`tests/test_asymptotic.py::TestBootstrapCiCoverage\`) that simulates from a known α(x) curve over 50 trials and asserts coverage of the 95% CI is in [0.7, 1.0]. This is more rigorous than any single real-dataset comparison and runs as part of the test suite.

## Out of scope (filed as follow-ups)

- **#16**: Vectorize \`_bootstrap_imputed_alpha\` to bypass per-replicate \`_compute_imputed\` list scans (~10–50× speedup expected). Pure perf; correctness is fine today.
- **#17**: Refactor per-gene \`asymptotic_mk_test\` bootstrap to call \`_compute_ci_bootstrap\` (eliminates ~60 lines of duplication; small behavior change in failure handling so deferred).

## Bonus

Fixed a pre-existing dev-environment issue: the venv had stale shebangs from a directory rename (\`mikado\` → \`mkado\`), which made \`uv run pytest\` silently fail to find typer when collecting \`test_cli.py\` / \`test_batch.py\` / \`test_vcf.py\`. Rebuilding the venv via \`uv sync\` fixed it. Now the **full 267-test suite** is green for the first time.

Also fixed three pre-existing ruff errors in \`src/mkado/io/plotting.py\` (unused \`scatter\` variable, two redundant f-strings) so \`ruff check src/mkado/\` is now clean.

## Test plan

- [x] \`uv run pytest\` — 267/267 pass
- [x] \`uv run ruff check src/mkado/\` — clean
- [x] \`uv run ruff format --check\` on touched files — clean
- [x] \`cd docs && sphinx-build -W --keep-going -b html . _build/html\` — strict build passes
- [x] CLI smoke tests on \`tests/data/kreitmanAdh.fa\` (asymptotic + imputed, both CI methods, all output formats)
- [x] 400-gene Anopheles batch sanity check (MC vs bootstrap; numbers above)
- [x] New \`TestBootstrapCi\` (7 tests), \`TestBootstrapCiCoverage\` (synthetic coverage), \`TestImputedBootstrapCi\` (8 tests), \`TestCiMethodOption\` (4 CLI tests)