### PR TITLE
perf: vectorize _bootstrap_imputed_alpha (closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@
   alongside the existing `_compute_ci_monte_carlo()`.
 - `_bootstrap_imputed_alpha()` helper in `mkado.analysis.imputed`.
 
+### Performance
+- `_bootstrap_imputed_alpha()` is now vectorized: pre-extracts numpy
+  arrays of frequencies and N/S type once, then per replicate uses
+  `rng.integers` indexing and `np.count_nonzero` instead of calling
+  `_compute_imputed` (which does four Python-level `sum()` passes per
+  call). ~63× speedup on the imputed-bootstrap path measured on a
+  ~1000-polymorphism gene with 1000 replicates (1.4 s → 22 ms). CIs are
+  byte-identical to the prior implementation under the same seed
+  (closes #16).
+
 ## [0.4.0] - 2026-03-17
 
 ### Added

--- a/src/mkado/analysis/imputed.py
+++ b/src/mkado/analysis/imputed.py
@@ -273,24 +273,44 @@ def _bootstrap_imputed_alpha(
 ) -> tuple[float, float] | None:
     """Bootstrap CI on imputed alpha by case-resampling the polymorphism list.
 
-    Each replicate draws ``len(polymorphisms)`` indices uniformly with
-    replacement and reruns the imputed MK algorithm. Returns ``None`` if
-    no successful replicate yields a defined alpha.
+    Vectorized: pre-extract ``freqs`` / ``is_n`` / ``is_low`` numpy arrays
+    once, then per replicate index with ``rng.integers`` and count via
+    ``np.count_nonzero``. The CI only needs alpha, so we inline the imputed
+    formula and skip Fisher's-exact, DFE fractions, and omega — all of which
+    ``_compute_imputed`` recomputes on every call but none of which feed the
+    percentile.
+
+    Returns ``None`` if fewer than half the replicates yield a defined alpha.
     """
     n = len(polymorphisms)
     if n == 0 or n_replicates <= 0:
         return None
+    if dn == 0:
+        # alpha is undefined for every replicate; skip the loop entirely.
+        return None
+
+    freqs = np.fromiter((f for f, _ in polymorphisms), dtype=float, count=n)
+    is_n = np.fromiter((t == "N" for _, t in polymorphisms), dtype=bool, count=n)
+    is_low = freqs <= cutoff
 
     rng = np.random.default_rng(seed)
     bootstrap_alphas: list[float] = []
     for _ in range(n_replicates):
-        sample_idx = rng.integers(0, n, size=n)
-        boot = [polymorphisms[i] for i in sample_idx]
-        boot_result = _compute_imputed(
-            boot, dn, ds, cutoff, num_synonymous_sites, num_nonsynonymous_sites
-        )
-        if boot_result.alpha is not None:
-            bootstrap_alphas.append(boot_result.alpha)
+        sample = rng.integers(0, n, size=n)
+        boot_n = is_n[sample]
+        boot_low = is_low[sample]
+        pn_low = int(np.count_nonzero(boot_n & boot_low))
+        pn_high = int(np.count_nonzero(boot_n & ~boot_low))
+        ps_low = int(np.count_nonzero(~boot_n & boot_low))
+        ps_high = int(np.count_nonzero(~boot_n & ~boot_low))
+
+        ps_total = ps_low + ps_high
+        if ps_total == 0:
+            continue
+        ratio_ps = ps_low / ps_high if ps_high else 0.0
+        pwd = max(pn_low - pn_high * ratio_ps, 0.0)
+        pn_neutral = (pn_low + pn_high) - pwd
+        bootstrap_alphas.append(1.0 - (pn_neutral / ps_total) * (ds / dn))
 
     if len(bootstrap_alphas) < n_replicates // 2:
         logger.debug(

--- a/tests/test_imputed.py
+++ b/tests/test_imputed.py
@@ -515,3 +515,34 @@ class TestImputedBootstrapCi:
         assert result.alpha_ci_low is not None
         assert result.alpha_ci_high is not None
         assert result.ci_method == "bootstrap"
+
+
+class TestImputedBootstrapRegression:
+    """Lock in the bootstrap CI numerics so vectorization stays byte-identical.
+
+    Issue #16 vectorizes the bootstrap to bypass per-replicate _compute_imputed
+    calls. The same seed must yield the same CI to all printable digits.
+    """
+
+    def test_single_gene_locked_ci(self) -> None:
+        gene = _imputed_fixture()
+        result = imputed_mk_test(gene, cutoff=0.15, n_bootstrap=500, seed=42)
+        # Recorded with the pre-vectorization implementation
+        assert result.alpha_ci_low == pytest.approx(0.19999999999999996, abs=1e-12)
+        assert result.alpha_ci_high == pytest.approx(0.9466666666666667, abs=1e-12)
+
+    def test_multi_gene_locked_ci(self) -> None:
+        gene1 = _imputed_fixture()
+        gene2 = PolymorphismData(
+            polymorphisms=[(0.05, "N")] * 3
+            + [(0.5, "N")] * 2
+            + [(0.4, "S")] * 5
+            + [(0.5, "S")] * 3,
+            dn=4,
+            ds=3,
+            ln=200.0,
+            ls=70.0,
+        )
+        result = imputed_mk_test_multi([gene1, gene2], cutoff=0.15, n_bootstrap=500, seed=42)
+        assert result.alpha_ci_low == pytest.approx(0.4046481092436975, abs=1e-12)
+        assert result.alpha_ci_high == pytest.approx(0.9233928571428571, abs=1e-12)


### PR DESCRIPTION
## Summary

Closes #16. Pure performance refactor — same seed produces byte-identical CIs.

The old implementation called \`_compute_imputed(boot, ...)\` per replicate. \`_compute_imputed\` itself does four Python-level \`sum()\` passes over the polymorphism list, plus a list comprehension to materialize the resampled list, plus computes Fisher's exact, DFE fractions, and the omega decomposition — none of which feed the percentile CI.

The new implementation:
- Pre-extracts \`freqs\`, \`is_n\`, \`is_low\` numpy arrays once before the replicate loop.
- Per replicate: \`rng.integers\` indexing + \`np.count_nonzero\` on boolean masks.
- Inlines the alpha formula; skips Fisher's, DFE, omega.
- Adds early-out for \`dn == 0\` (alpha undefined for every replicate); per-replicate skip for \`ps_total == 0\`.

## Speedup

Measured on a ~1000-polymorphism gene with 1000 replicates:

| | Time | Speedup |
|---|---|---|
| Old (\`_compute_imputed\` per replicate) | 1380 ms | — |
| New (vectorized) | 22 ms | **63×** |

Above the 10–50× the issue predicted.

## Correctness

Same seed yields **byte-identical** CIs. Two new regression tests (\`TestImputedBootstrapRegression\`) lock the numerics to twelve decimal places against the pre-refactor values:

- single-gene fixture: \`(0.19999999999999996, 0.9466666666666667)\`
- multi-gene fixture: \`(0.4046481092436975, 0.9233928571428571)\`

These were recorded against the prior implementation, then verified to pass against the vectorized one.

## Test plan

- [x] \`uv run pytest\` — 269/269 pass (267 + 2 new regression tests)
- [x] \`TestImputedBootstrapRegression\` locks byte-identical CI output
- [x] All existing imputed-bootstrap tests pass
- [x] \`uv run ruff check src/mkado/\` — clean