### PR TITLE
asymptotic: share bootstrap helper between per-gene and aggregated paths (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,18 @@
   ~1000-polymorphism gene with 1000 replicates (1.4 s → 22 ms). CIs are
   byte-identical to the prior implementation under the same seed
   (closes #16).
+- Per-gene `asymptotic_mk_test` bootstrap loop replaced by a call to
+  the shared `_compute_ci_bootstrap()` helper (closes #17). Removes
+  ~60 lines of duplicate code, vectorizes the per-replicate binning,
+  and aligns failure-handling between per-gene and aggregated paths.
+
+### Changed
+- Per-gene `asymptotic_mk_test` CI failure handling: replicates whose
+  curve fit fails are now **dropped** rather than imputed with the last
+  bin's alpha (the prior behavior biased the CI when fits failed
+  systematically). When fewer than half of replicates succeed, the CI
+  degenerates to the point estimate. Matches the aggregated path's
+  behavior added in #10.
 
 ## [0.4.0] - 2026-03-17
 

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -1069,68 +1069,25 @@ def asymptotic_mk_test(
         a, b, c = y_data[-1], 0.0, 1.0
         alpha_asymp = y_data[-1]
 
-    # Bootstrap for confidence intervals
-    bootstrap_alphas = []
-    rng = np.random.default_rng(42)
-
-    for _ in range(bootstrap_replicates):
-        # Resample polymorphism data
-        if len(poly_data) == 0:
-            continue
-
-        indices = rng.integers(0, len(poly_data), size=len(poly_data))
-        boot_data = [poly_data[i] for i in indices]
-
-        # Bin resampled polymorphisms
-        boot_pn_per_bin = [0] * num_bins
-        boot_ps_per_bin = [0] * num_bins
-
-        for freq, poly_type in boot_data:
-            bin_idx = int(np.searchsorted(bin_edges[1:], freq, side="right"))
-            bin_idx = min(bin_idx, num_bins - 1)
-            if poly_type == "N":
-                boot_pn_per_bin[bin_idx] += 1
-            else:
-                boot_ps_per_bin[bin_idx] += 1
-
-        # Recalculate per-bin alpha values
-        boot_alpha_values = []
-        boot_centers = []
-
-        for i in range(num_bins):
-            pn_bin = boot_pn_per_bin[i]
-            ps_bin = boot_ps_per_bin[i]
-
-            if ds > 0 and dn > 0 and ps_bin > 0:
-                alpha_x = 1.0 - (ds / dn) * (pn_bin / ps_bin)
-                boot_alpha_values.append(alpha_x)
-                boot_centers.append(bin_centers[i])
-
-        if len(boot_centers) >= 3:
-            try:
-                boot_x = np.array(boot_centers)
-                boot_y = np.array(boot_alpha_values)
-                popt_boot, _ = optimize.curve_fit(
-                    _exponential_model,
-                    boot_x,
-                    boot_y,
-                    p0=[a, b, c],
-                    bounds=bounds,
-                    maxfev=5000,
-                )
-                # Evaluate at x=1: α(1) = a + b * exp(-c)
-                a_boot, b_boot, c_boot = popt_boot
-                bootstrap_alphas.append(a_boot + b_boot * np.exp(-c_boot))
-            except (RuntimeError, ValueError):
-                bootstrap_alphas.append(boot_alpha_values[-1] if boot_alpha_values else alpha_asymp)
-
-    # Calculate 95% CI
-    if bootstrap_alphas:
-        ci_low = float(np.percentile(bootstrap_alphas, 2.5))
-        ci_high = float(np.percentile(bootstrap_alphas, 97.5))
-    else:
-        ci_low = alpha_asymp
-        ci_high = alpha_asymp
+    # Shares the case-resampling bootstrap with the aggregated path.
+    # Replicates whose curve_fit fails are dropped (rather than imputed
+    # with the last bin's alpha as the legacy per-gene path did); CI
+    # degenerates to the point estimate when fewer than half succeed.
+    ci_low, ci_high = _compute_ci_bootstrap(
+        poly_data,
+        dn,
+        ds,
+        bin_edges,
+        bin_centers,
+        num_bins,
+        _exponential_model,
+        [float(a), float(b), float(c)],
+        bounds,
+        (0.0, 1.0),  # per-gene path has no frequency cutoff for fitting
+        alpha_asymp,
+        n_replicates=bootstrap_replicates,
+        seed=42,
+    )
 
     result = AsymptoticMKResult(
         frequency_bins=list(bin_centers),

--- a/tests/test_asymptotic.py
+++ b/tests/test_asymptotic.py
@@ -127,6 +127,26 @@ ATGATG
         # With only 4 ingroup sequences, might not have enough frequency data
         # but should still complete
 
+    def test_asymptotic_mk_test_ci_method_is_bootstrap(self, tmp_path: Path) -> None:
+        """Per-gene CI is reported as bootstrap (shares _compute_ci_bootstrap)."""
+        ingroup_fa = tmp_path / "ingroup.fa"
+        ingroup_fa.write_text(""">seq1
+ATGATGATGATGATGATG
+>seq2
+ATGCTGATGATGATGATG
+>seq3
+ATGATGATGCTGATGATG
+""")
+        outgroup_fa = tmp_path / "outgroup.fa"
+        outgroup_fa.write_text(""">out1
+ATGGTGATGGTGATGGTG
+""")
+        result = asymptotic_mk_test(ingroup_fa, outgroup_fa, num_bins=5)
+        assert result.ci_method == "bootstrap"
+        # CI should always be a valid interval (low <= high), even when it
+        # degenerates to the point estimate on small fixtures.
+        assert result.ci_low <= result.ci_high
+
 
 class TestPolymorphismData:
     """Tests for PolymorphismData dataclass."""


### PR DESCRIPTION
## Summary

Closes #17. Replace the inline per-gene bootstrap loop in \`asymptotic_mk_test\` with a call to the shared \`_compute_ci_bootstrap()\` helper added in #10.

| | |
|---|---|
| Net diff | **−43 lines** (−62 deleted, +19 added) |
| Vectorization | Per-replicate binning now uses \`np.bincount\` instead of Python for-loops |
| Tests | 270/270 pass (added one regression test) |

## Behavior change

The legacy per-gene loop, when \`curve_fit\` failed on a replicate, appended \`boot_alpha_values[-1]\` (or \`alpha_asymp\`) — biases the CI when fits fail systematically. The shared helper drops failed replicates and falls back to the point estimate only when fewer than half of replicates succeeded.

This matches the **aggregated path's** behavior since #10. CHANGELOG documents the change under \`### Changed\`.

In practice the difference is small: the existing per-gene tests pass unchanged, and small-fixture cases where curve_fit fails frequently now produce CIs that degenerate to the point estimate (more honest than imputing the last bin's alpha).

## What was deduplicated

Per the issue, the new helper aligned five things between the per-gene and aggregated paths:

1. **Algorithm**: shared \`_compute_ci_bootstrap()\`.
2. **Vectorization**: \`np.bincount\` instead of Python loops.
3. **Failure handling**: drop failed replicates; fall back to point estimate only when <50% succeed.
4. **Model fixing**: held to the point-estimate model (the per-gene path always uses exponential, so this is moot today, but stays consistent if the per-gene path ever adds linear-fallback).
5. **Frequency cutoffs**: per-gene passes \`(0.0, 1.0)\` (no cutoff) since it never restricts the fit window.

## Test plan

- [x] \`uv run pytest\` — 270/270 pass
- [x] All existing per-gene asymptotic tests pass unchanged
- [x] New \`test_asymptotic_mk_test_ci_method_is_bootstrap\` asserts \`ci_method=\"bootstrap\"\` and a valid CI interval on a small fixture
- [x] \`uv run ruff check src/mkado/\` — clean