### PR TITLE
fix: eager-precompute GeneticCode translate cache (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,20 @@
   ~60 lines of duplicate code, vectorizes the per-replicate binning,
   and aligns failure-handling between per-gene and aggregated paths.
 
+### Fixed
+- `GeneticCode.translate` no longer uses `@lru_cache` on a bound method
+  (closes #14). The decorator's cache key included `self`, pinning every
+  `GeneticCode` instance for the lifetime of the class object — a real
+  leak in tests, notebooks, and any process that constructs many
+  ephemeral instances. The translation table is now eagerly precomputed
+  in `__init__` as a per-instance dict (~640 bytes), mirroring the
+  proven `_compute_codon_paths` pattern. Same fix applied to
+  `count_synonymous_sites`, retiring its lazy-population dict for an
+  eager precompute over the bounded 64-codon keyspace. Behavior is
+  byte-identical for callers; a new regression test in
+  `tests/test_codons.py::TestGeneticCodeMemory` uses `weakref` to verify
+  instances are garbage-collected after `del` + `gc.collect()`.
+
 ### Changed
 - Per-gene `asymptotic_mk_test` CI failure handling: replicates whose
   curve fit fails are now **dropped** rather than imputed with the last

--- a/src/mkado/core/codons.py
+++ b/src/mkado/core/codons.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from mkado.data.genetic_codes import (
@@ -49,9 +48,16 @@ class GeneticCode:
         else:
             self._paths = _compute_codon_paths(self.code)
 
-        self._syn_sites_cache: dict[str, float] = {}
+        # Eager per-instance lookup tables over the 64 standard codons. Keyspace
+        # is fixed by self.code; non-standard inputs (N, -, lowercase, "XYZ", ...)
+        # fall through the .get() default at lookup time. Avoiding @lru_cache on
+        # bound methods is deliberate — that pattern keeps `self` alive via the
+        # cache key, leaking instances (regression test in tests/test_codons.py).
+        self._translate_cache: dict[str, str] = dict(self.code)
+        self._syn_sites_cache: dict[str, float] = {
+            codon: self._compute_syn_sites(codon) for codon in self.code
+        }
 
-    @lru_cache(maxsize=4096)
     def translate(self, codon: str) -> str:
         """Translate a codon to its amino acid.
 
@@ -61,8 +67,35 @@ class GeneticCode:
         Returns:
             Single-letter amino acid code, or 'X' for unknown
         """
-        codon = codon.upper()
-        return self.code.get(codon, "X")
+        return self._translate_cache.get(codon.upper(), "X")
+
+    def _compute_syn_sites(self, codon: str) -> float:
+        """Nei-Gojobori synonymous-site count for one codon.
+
+        Used during ``__init__`` to populate ``_syn_sites_cache`` and not
+        called afterwards. Reads ``_translate_cache``, which must already be
+        built when this is invoked.
+        """
+        aa = self._translate_cache.get(codon, "X")
+        if aa == "*" or aa == "X":
+            return 0.0
+
+        syn_sites = 0.0
+        for pos in range(3):
+            syn_count = 0
+            total_count = 0
+            for nt in ("A", "C", "G", "T"):
+                if nt == codon[pos]:
+                    continue
+                new_codon = codon[:pos] + nt + codon[pos + 1 :]
+                new_aa = self._translate_cache.get(new_codon, "X")
+                if new_aa != "*":
+                    total_count += 1
+                    if new_aa == aa:
+                        syn_count += 1
+            if total_count > 0:
+                syn_sites += syn_count / total_count
+        return syn_sites
 
     def translate_sequence(self, sequence: str, reading_frame: int = 1) -> str:
         """Translate a nucleotide sequence to amino acids.
@@ -110,39 +143,9 @@ class GeneticCode:
             Number of synonymous sites (0-3)
         """
         codon = codon.upper()
-        cached = self._syn_sites_cache.get(codon)
-        if cached is not None:
-            return cached
-
         if "N" in codon or "-" in codon:
-            self._syn_sites_cache[codon] = 0.0
             return 0.0
-
-        aa = self.translate(codon)
-        if aa == "*" or aa == "X":
-            self._syn_sites_cache[codon] = 0.0
-            return 0.0
-
-        syn_sites = 0.0
-        nucleotides = ["A", "C", "G", "T"]
-
-        for pos in range(3):
-            syn_count = 0
-            total_count = 0
-            for nt in nucleotides:
-                if nt == codon[pos]:
-                    continue
-                new_codon = codon[:pos] + nt + codon[pos + 1 :]
-                new_aa = self.translate(new_codon)
-                if new_aa != "*":
-                    total_count += 1
-                    if new_aa == aa:
-                        syn_count += 1
-            if total_count > 0:
-                syn_sites += syn_count / total_count
-
-        self._syn_sites_cache[codon] = syn_sites
-        return syn_sites
+        return self._syn_sites_cache.get(codon, 0.0)
 
     def is_synonymous_change(self, codon1: str, codon2: str) -> bool | None:
         """Check if a single-nucleotide change is synonymous.

--- a/tests/test_codons.py
+++ b/tests/test_codons.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from mkado.core.codons import DEFAULT_CODE, GeneticCode
+from mkado.core.codons import GeneticCode
 
 
 class TestGeneticCode:
@@ -201,3 +201,40 @@ class TestResolveCodeTable:
 
         with pytest.raises(ValueError, match="Unknown genetic code"):
             resolve_code_table("99")
+
+
+class TestGeneticCodeMemory:
+    """Regression tests for #14: GeneticCode instances must not be pinned by their cache.
+
+    The prior `@lru_cache(maxsize=4096)` on the bound `translate` method held a
+    strong reference to ``self`` through the cache key, preventing the instance
+    from being garbage-collected until the cached method itself was dropped.
+    """
+
+    def test_instance_collected_after_translate_use(self) -> None:
+        import gc
+        import weakref
+
+        code = GeneticCode()
+        for codon in ("ATG", "TTT", "TGA", "GCC"):
+            code.translate(codon)
+            code.count_synonymous_sites(codon)
+        ref = weakref.ref(code)
+        del code
+        gc.collect()
+        assert ref() is None, "GeneticCode instance not collected after del + gc.collect()"
+
+    def test_many_instances_collected(self) -> None:
+        import gc
+        import weakref
+
+        refs = []
+        for _ in range(50):
+            c = GeneticCode()
+            c.translate("ATG")
+            c.count_synonymous_sites("TTT")
+            refs.append(weakref.ref(c))
+            del c
+        gc.collect()
+        live = sum(1 for r in refs if r() is not None)
+        assert live == 0, f"{live}/{len(refs)} GeneticCode instances still alive"


### PR DESCRIPTION
## Summary

Closes #14. Replace \`@lru_cache(maxsize=4096)\` on \`GeneticCode.translate\` (a bound method) with an eager per-instance dict built in \`__init__\`. The decorator's cache key included \`self\`, holding every \`GeneticCode\` instance alive for the lifetime of the class object.

## Confirmed leak (regression test)

\`tests/test_codons.py::TestGeneticCodeMemory\` uses \`weakref\` to verify the leak existed and is fixed:

| | old (@lru_cache) | new (eager dict) |
|---|---|---|
| \`del code; gc.collect()\` then \`weakref()\` | not None (alive) | None (collected) |
| 50 ephemeral instances after \`gc.collect()\` | **50/50 alive** | 0/50 alive |

Both tests fail under the old implementation and pass under the new.

## What changed

- \`@lru_cache\` decorator removed from \`GeneticCode.translate\`. Body is now \`return self._translate_cache.get(codon.upper(), \"X\")\`.
- \`_translate_cache: dict[str, str] = dict(self.code)\` is eagerly populated in \`__init__\` from the 64-entry \`self.code\` dict. ~640 bytes per instance.
- Same eager-precompute treatment for \`_syn_sites_cache\` (retiring the lazy-population dict added in #9). The Nei-Gojobori per-codon work moves to a private \`_compute_syn_sites\` helper called only from the constructor.
- The user's concern about the per-instance dict pattern (unbounded growth from unusual inputs) is addressed: keyspace is now fixed at init time (the 64 keys of \`self.code\`); non-standard inputs (N, gaps, lowercase variants, \"XYZ\") fall through the \`.get()\` default at lookup time and are never cached.
- \`from functools import lru_cache\` removed (unused after the change). Audit confirmed \`@lru_cache\` was the only one in \`src/mkado/\`.

## Behavior preservation

Byte-identical for callers:
- All 64 standard codons → same amino acid (lookup is straight from \`self.code\`).
- N-containing, gap-containing, lowercase, mixed-case → same \`\"X\"\` / \`0.0\` via \`.get(..., default)\`.
- Stop codons → \`0.0\` from \`count_synonymous_sites\` (the precompute helper short-circuits when \`aa == \"*\"\`).
- Kreitman smoke test: \`Dn=6, Ds=8, Pn=1, Ps=8, Ln=576, Ls=195\` unchanged.

## Microbenchmark

| | per call |
|---|---|
| \`translate(\"TTT\")\` | 0.226 µs |
| \`count_synonymous_sites(\"TTT\")\` | 0.264 µs |
| \`GeneticCode()\` construction | 0.19 ms |

The eager precompute adds a small construction cost (≈5% on top of the existing \`_compute_codon_paths\` work for custom \`code\` dicts; near-zero for table_id-based instances which reuse \`get_codon_paths\`'s module-level cache). Per-call overhead drops slightly vs the old hashed-tuple-key lru_cache lookup.

## Test plan

- [x] \`uv run pytest tests/test_codons.py\` — all 25 (23 existing + 2 new memory tests) pass
- [x] \`uv run pytest\` — full 272/272 suite green
- [x] \`uv run ruff check src/mkado/core/codons.py tests/test_codons.py\` — clean
- [x] \`uv run ruff format --check\` on touched files — clean
- [x] CLI smoke test on Kreitman fixture: \`Dn=6, Ds=8, Ln=576, Ls=195\` unchanged