### PR TITLE
Standardize missing-value rendering on "NA" (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@
   byte-identical for callers; a new regression test in
   `tests/test_codons.py::TestGeneticCodeMemory` uses `weakref` to verify
   instances are garbage-collected after `del` + `gc.collect()`.
+- Standardized missing-value rendering on the literal `"NA"` (no slash)
+  across pretty and TSV output (closes #13). The dataclass `__str__`
+  methods previously rendered `"N/A"` while the TSV formatters used
+  `"NA"` — a user piping pretty output through R/awk that parses `"NA"`
+  would have silently missed `"N/A"` rows. JSON renders `null`,
+  unchanged. New regression suite in `tests/test_output_format.py`
+  guards both the convention and the absence of `"N/A"` in any output
+  format.
 
 ### Changed
 - Per-gene `asymptotic_mk_test` CI failure handling: replicates whose

--- a/src/mkado/analysis/alpha_tg.py
+++ b/src/mkado/analysis/alpha_tg.py
@@ -103,8 +103,8 @@ class AlphaTGResult:
         if self.ln is not None and self.ls is not None:
             lines.append(f"  Sites:         Ln={self.ln:.2f}, Ls={self.ls:.2f}")
         if self.omega is not None:
-            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
-            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
+            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "NA"
+            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "NA"
             lines.append(
                 f"  omega:         {self.omega:.4f} "
                 f"(omega_a={omega_a_str}, omega_na={omega_na_str})"

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -176,8 +176,8 @@ class AsymptoticMKResult:
         if self.ln is not None and self.ls is not None:
             lines.append(f"  Sites: Ln={self.ln:.2f}, Ls={self.ls:.2f}")
         if self.omega is not None:
-            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
-            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
+            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "NA"
+            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "NA"
             lines.append(
                 f"  omega: {self.omega:.4f} (omega_a={omega_a_str}, omega_na={omega_na_str})"
             )

--- a/src/mkado/analysis/imputed.py
+++ b/src/mkado/analysis/imputed.py
@@ -110,7 +110,7 @@ class ImputedMKResult:
         return (1.0 - self.alpha_ci_low) * self.omega
 
     def __str__(self) -> str:
-        alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "N/A"
+        alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "NA"
         lines = [
             "Imputed MK Test Results:",
             f"  Divergence:    Dn={self.dn}, Ds={self.ds}",
@@ -129,8 +129,8 @@ class ImputedMKResult:
         if self.ln is not None and self.ls is not None:
             lines.append(f"  Sites:         Ln={self.ln:.2f}, Ls={self.ls:.2f}")
         if self.omega is not None:
-            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "N/A"
-            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "N/A"
+            omega_a_str = f"{self.omega_a:.4f}" if self.omega_a is not None else "NA"
+            omega_na_str = f"{self.omega_na:.4f}" if self.omega_na is not None else "NA"
             lines.append(
                 f"  omega:         {self.omega:.4f} "
                 f"(omega_a={omega_a_str}, omega_na={omega_na_str})"

--- a/src/mkado/analysis/mk_test.py
+++ b/src/mkado/analysis/mk_test.py
@@ -67,12 +67,12 @@ class MKResult:
     """
 
     def __str__(self) -> str:
-        ni_str = f"{self.ni:.4f}" if self.ni is not None else "N/A"
-        alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "N/A"
-        dos_str = f"{self.dos:.4f}" if self.dos is not None else "N/A"
-        omega_str = f"{self.omega:.4f}" if self.omega is not None else "N/A"
-        ls_str = f"{self.ls:.2f}" if self.ls is not None else "N/A"
-        ln_str = f"{self.ln:.2f}" if self.ln is not None else "N/A"
+        ni_str = f"{self.ni:.4f}" if self.ni is not None else "NA"
+        alpha_str = f"{self.alpha:.4f}" if self.alpha is not None else "NA"
+        dos_str = f"{self.dos:.4f}" if self.dos is not None else "NA"
+        omega_str = f"{self.omega:.4f}" if self.omega is not None else "NA"
+        ls_str = f"{self.ls:.2f}" if self.ls is not None else "NA"
+        ln_str = f"{self.ln:.2f}" if self.ln is not None else "NA"
         return (
             f"MK Test Results:\n"
             f"  Divergence:    Dn={self.dn}, Ds={self.ds}\n"

--- a/src/mkado/analysis/polarized.py
+++ b/src/mkado/analysis/polarized.py
@@ -80,12 +80,12 @@ class PolarizedMKResult:
     """
 
     def __str__(self) -> str:
-        ni_str = f"{self.ni_ingroup:.4f}" if self.ni_ingroup is not None else "N/A"
-        alpha_str = f"{self.alpha_ingroup:.4f}" if self.alpha_ingroup is not None else "N/A"
-        dos_str = f"{self.dos_ingroup:.4f}" if self.dos_ingroup is not None else "N/A"
-        omega_str = f"{self.omega:.4f}" if self.omega is not None else "N/A"
-        ls_str = f"{self.ls:.2f}" if self.ls is not None else "N/A"
-        ln_str = f"{self.ln:.2f}" if self.ln is not None else "N/A"
+        ni_str = f"{self.ni_ingroup:.4f}" if self.ni_ingroup is not None else "NA"
+        alpha_str = f"{self.alpha_ingroup:.4f}" if self.alpha_ingroup is not None else "NA"
+        dos_str = f"{self.dos_ingroup:.4f}" if self.dos_ingroup is not None else "NA"
+        omega_str = f"{self.omega:.4f}" if self.omega is not None else "NA"
+        ls_str = f"{self.ls:.2f}" if self.ls is not None else "NA"
+        ln_str = f"{self.ln:.2f}" if self.ln is not None else "NA"
         return (
             f"Polarized MK Test Results:\n"
             f"  Ingroup Lineage:\n"

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -1,0 +1,148 @@
+"""Tests for output-format conventions (issue #13).
+
+MKado renders missing/undefined floats as the literal ``"NA"`` (no slash) in
+both pretty and TSV output, matching the R/Pandas convention. JSON uses
+``null``. These tests guard against regressions where one format drifts
+from another.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mkado.analysis.alpha_tg import AlphaTGResult
+from mkado.analysis.asymptotic import AsymptoticMKResult
+from mkado.analysis.imputed import ImputedMKResult
+from mkado.analysis.mk_test import MKResult, mk_test_from_counts
+from mkado.analysis.polarized import PolarizedMKResult
+from mkado.io.output import OutputFormat, format_result
+
+
+@pytest.fixture
+def mk_undefined() -> MKResult:
+    """Counts where alpha/NI/DoS/omega all degenerate to None."""
+    # Dn=0 forces alpha and NI to None; Dn+Ds=0 and Pn+Ps=0 forces DoS to None.
+    return mk_test_from_counts(dn=0, ds=0, pn=0, ps=0)
+
+
+@pytest.fixture
+def asymptotic_undefined() -> AsymptoticMKResult:
+    return AsymptoticMKResult(
+        alpha_asymptotic=0.0,
+        ci_low=0.0,
+        ci_high=0.0,
+        dn=0,
+        ds=0,
+        # ln/ls left None → omega/omega_a/omega_na all None
+    )
+
+
+@pytest.fixture
+def imputed_undefined() -> ImputedMKResult:
+    return ImputedMKResult(
+        alpha=None,
+        p_value=1.0,
+        pn_neutral=0.0,
+        pwd=0.0,
+        dn=0,
+        ds=0,
+        pn_total=0,
+        ps_total=0,
+        cutoff=0.15,
+    )
+
+
+@pytest.fixture
+def alpha_tg_undefined() -> AlphaTGResult:
+    return AlphaTGResult(
+        alpha_tg=0.0,
+        ni_tg=0.0,
+        ci_low=0.0,
+        ci_high=0.0,
+        num_genes=0,
+        dn_total=0,
+        ds_total=0,
+        pn_total=0,
+        ps_total=0,
+        # ln/ls left None → omega/omega_a/omega_na all None
+    )
+
+
+@pytest.fixture
+def polarized_undefined() -> PolarizedMKResult:
+    return PolarizedMKResult(
+        dn_ingroup=0,
+        ds_ingroup=0,
+        pn_ingroup=0,
+        ps_ingroup=0,
+        dn_outgroup=0,
+        ds_outgroup=0,
+        dn_unpolarized=0,
+        ds_unpolarized=0,
+        pn_unpolarized=0,
+        ps_unpolarized=0,
+        p_value_ingroup=1.0,
+        ni_ingroup=None,
+        alpha_ingroup=None,
+        dos_ingroup=None,
+    )
+
+
+_ALL_UNDEFINED = [
+    "mk_undefined",
+    "asymptotic_undefined",
+    "imputed_undefined",
+    "alpha_tg_undefined",
+    "polarized_undefined",
+]
+
+
+@pytest.mark.parametrize("fixture_name", _ALL_UNDEFINED)
+def test_pretty_output_never_uses_N_slash_A(
+    fixture_name: str, request: pytest.FixtureRequest
+) -> None:
+    """Pretty output must never render missing values as ``"N/A"`` (with slash)."""
+    result = request.getfixturevalue(fixture_name)
+    pretty = str(result)
+    assert "N/A" not in pretty, f"{fixture_name}: pretty output uses 'N/A'\n{pretty}"
+
+
+@pytest.mark.parametrize("fixture_name", _ALL_UNDEFINED)
+def test_tsv_output_never_uses_N_slash_A(fixture_name: str, request: pytest.FixtureRequest) -> None:
+    """TSV output must never render missing values as ``"N/A"`` (with slash)."""
+    result = request.getfixturevalue(fixture_name)
+    tsv = format_result(result, OutputFormat.TSV)
+    assert "N/A" not in tsv, f"{fixture_name}: TSV output uses 'N/A'\n{tsv}"
+
+
+@pytest.mark.parametrize("fixture_name", _ALL_UNDEFINED)
+def test_json_never_uses_N_slash_A_or_string_NA(
+    fixture_name: str, request: pytest.FixtureRequest
+) -> None:
+    """JSON renders missing values as ``null``, never ``"N/A"`` or string ``"NA"``."""
+    result = request.getfixturevalue(fixture_name)
+    js = format_result(result, OutputFormat.JSON)
+    assert "N/A" not in js, f"{fixture_name}: JSON contains 'N/A'\n{js}"
+    # Sanity: it parses and at least one value round-trips
+    parsed = json.loads(js)
+    assert parsed is not None
+
+
+def test_pretty_NA_appears_when_alpha_undefined() -> None:
+    """Targeted check: when alpha is None, MKResult.__str__ emits the literal 'NA'."""
+    # dn=0, ds=0, pn=0, ps=0 → ni/alpha/dos all None → all three rendered as "NA"
+    result = mk_test_from_counts(dn=0, ds=0, pn=0, ps=0)
+    pretty = str(result)
+    # Three "NA" tokens (NI, alpha, DoS lines), at minimum
+    assert pretty.count("NA") >= 3, f"expected ≥3 NA tokens; got:\n{pretty}"
+
+
+def test_tsv_NA_appears_when_alpha_undefined() -> None:
+    """Targeted check: when alpha is None, MKResult TSV emits the literal 'NA'."""
+    result = mk_test_from_counts(dn=0, ds=0, pn=0, ps=0)
+    tsv = format_result(result, OutputFormat.TSV)
+    # TSV header has no NA; data row has NA wherever a None field landed
+    _, values = tsv.split("\n")
+    assert "NA" in values.split("\t"), f"expected NA among TSV fields; got:\n{tsv}"


### PR DESCRIPTION
## Summary

Closes #13. Pretty output rendered missing values as \`\"N/A\"\` (with slash); TSV formatters used \`\"NA\"\` (no slash). A user piping pretty output through R or awk parsing \`\"NA\"\` would have silently missed \`\"N/A\"\` rows.

This PR standardizes both formats on \`\"NA\"\` (the R / Pandas convention recommended in the issue). JSON renders \`null\` and is unaffected.

## What changed

- **19 \`\"N/A\"\` literals → \`\"NA\"\`** across the five result-class \`__str__\` methods:
  - \`src/mkado/analysis/mk_test.py\` — 6 occurrences (NI, alpha, DoS, omega, Ln, Ls)
  - \`src/mkado/analysis/polarized.py\` — 6 occurrences (same set, ingroup-flavored)
  - \`src/mkado/analysis/imputed.py\` — 3 occurrences (alpha, omega_a, omega_na)
  - \`src/mkado/analysis/asymptotic.py\` — 2 occurrences (omega_a, omega_na)
  - \`src/mkado/analysis/alpha_tg.py\` — 2 occurrences (omega_a, omega_na)
- TSV path already used \`\"NA\"\` via \`_fmt_optional()\` in \`src/mkado/io/output.py\` — no change.
- New regression test file \`tests/test_output_format.py\` with **17 parametrized tests** asserting \`\"N/A\"\` never appears in pretty / TSV / JSON output across all five result types, plus two targeted checks that \`\"NA\"\` actually surfaces when alpha-undefined fixtures are rendered.

## Test plan

- [x] \`uv run pytest\` — 289/289 pass (272 + 17 new)
- [x] \`uv run ruff check src/mkado/ tests/test_output_format.py\` — clean
- [x] No existing tests asserted on the old \`\"N/A\"\` text, so no test updates were needed
- [x] Smoke test of \`mkado test --imputed --bootstrap 200\` shows the \`\"NA\"\` literal where alpha is undefined

## Out of scope

The issue's bonus criterion mentioned consolidating to a single \`MISSING_VALUE\` constant. I left the \`\"NA\"\` string inlined in each \`__str__\` because (a) putting a constant in a neutral module would create a cross-module import where there isn't one today, and (b) the regression test directly guards against drift. Easy to follow up later if it bites.