### PR TITLE
Asymptotic MK: --sfs-mode {at,above} for Uricchio 2019 cumulative SFS

### DIFF
--- a/docs/asymptotic.rst
+++ b/docs/asymptotic.rst
@@ -43,6 +43,33 @@ Where:
 
 As *x* approaches 1.0, deleterious polymorphisms are increasingly purged, and α(x) converges to the true proportion of adaptive substitutions.
 
+SFS Construction: At-x vs Above-x
+---------------------------------
+
+MKado supports two definitions of P\ :sub:`n`\ (x) and P\ :sub:`s`\ (x) — the per-bin form from `Messer & Petrov 2013`_ and the cumulative form introduced by `Uricchio et al. 2019`_. They share the asymptote at *x* = 1 but differ in finite-sample stability.
+
+**At-x mode** (``--sfs-mode at``, default):
+
+.. math::
+
+   P_n(x), P_s(x) = \text{count of polymorphisms in bin centered at } x
+
+This is the per-bin SFS. At large sample sizes the high-frequency bins become sparse, which inflates the per-bin α(x) noise and destabilizes the curve fit.
+
+**Above-x mode** (``--sfs-mode above``):
+
+.. math::
+
+   P_n(x), P_s(x) = \text{count of polymorphisms with derived frequency } \ge x
+
+This is the inclusive right-tail cumulative SFS. The two modes share the asymptote at *x* = 1 (where both definitions go to zero), but the cumulative form averages out per-bin noise and is more stable as sample size grows.
+
+The default is ``at`` for backward compatibility. The ``above`` form follows the convention used by `MKtest.jl <https://github.com/jmurga/MKtest.jl>`_ and the analyses in Uricchio et al. 2019; pass ``--sfs-mode above`` to switch.
+
+.. code-block:: bash
+
+   mkado batch alignments/ -i ingroup -o outgroup -a --sfs-mode above
+
 Determining Derived Allele Frequency
 ------------------------------------
 
@@ -284,13 +311,17 @@ References
 ----------
 
 .. _Haller & Messer 2017: https://doi.org/10.1534/g3.117.039693
+.. _Messer & Petrov 2013: https://doi.org/10.1073/pnas.1220835110
 .. _Messer & Petrov (2013): https://doi.org/10.1073/pnas.1220835110
+.. _Uricchio et al. 2019: https://doi.org/10.1038/s41559-019-0890-6
 .. _Gossmann, Keightley & Eyre-Walker 2012: https://doi.org/10.1093/gbe/evs027
 .. _Coronado-Zamora et al. 2019: https://doi.org/10.1093/gbe/evz046
 
 Haller BC, Messer PW (2017) asymptoticMK: A web-based tool for the asymptotic McDonald–Kreitman test. *G3: Genes, Genomes, Genetics* 7(5):1569-1575. https://doi.org/10.1534/g3.117.039693
 
 Messer PW, Petrov DA (2013) Frequent adaptation and the McDonald–Kreitman test. *PNAS* 110(21):8615-8620. https://doi.org/10.1073/pnas.1220835110
+
+Uricchio LH, Petrov DA, Enard D (2019) Exploiting selection at linked sites to infer the rate and strength of adaptation. *Nature Ecology & Evolution* 3:977-984. https://doi.org/10.1038/s41559-019-0890-6
 
 Gossmann TI, Keightley PD, Eyre-Walker A (2012) The effect of variation in the effective population size on the rate of adaptive molecular evolution in eukaryotes. *Genome Biology and Evolution* 4(5):658-667. https://doi.org/10.1093/gbe/evs027
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -135,6 +135,9 @@ The output reports which model was selected (exponential or linear) along with t
    # Customize number of frequency bins
    mkado test examples/anopheles_batch/AGAP000078.fa -i gamb -o afun -a -b 20
 
+   # Switch to the Uricchio et al. 2019 cumulative SFS (more sample-size-stable)
+   mkado test examples/anopheles_batch/AGAP000078.fa -i gamb -o afun -a --sfs-mode above
+
 The output includes:
 
 - **Alpha asymptotic**: Extrapolated alpha value at derived frequency = 1
@@ -142,6 +145,8 @@ The output includes:
 - **ci_method**: ``"monte-carlo"`` (default — parametric MVN sampling from the
   fit covariance) or ``"bootstrap"`` (case-resampling). Switch with
   ``--ci-method bootstrap``. See :doc:`asymptotic` for the trade-offs.
+- **sfs_mode**: ``"at"`` (default, per-bin SFS) or ``"above"`` (cumulative
+  SFS as in Uricchio et al. 2019). See :doc:`asymptotic` for the difference.
 - **Model type**: Whether exponential or linear model was selected
 - **Per-bin alpha values**: Alpha estimates at each frequency class
 - **omega, omega_a, omega_na**: dN/dS and its adaptive / non-adaptive

--- a/src/mkado/analysis/asymptotic.py
+++ b/src/mkado/analysis/asymptotic.py
@@ -57,9 +57,9 @@ class AggregatedSFS:
 
     bin_edges: np.ndarray = field(default_factory=lambda: np.array([]))
     pn_counts: np.ndarray = field(default_factory=lambda: np.array([]))
-    """Pn per bin."""
+    """Pn per bin (semantics depend on ``sfs_mode``: per-bin or cumulative tail)."""
     ps_counts: np.ndarray = field(default_factory=lambda: np.array([]))
-    """Ps per bin."""
+    """Ps per bin (semantics depend on ``sfs_mode``: per-bin or cumulative tail)."""
     dn_total: int = 0
     ds_total: int = 0
     num_genes: int = 0
@@ -67,6 +67,12 @@ class AggregatedSFS:
     """Sum of per-gene Nei-Gojobori non-synonymous sites."""
     ls_total: float | None = None
     """Sum of per-gene Nei-Gojobori synonymous sites."""
+    pn_total: int = 0
+    """Total non-synonymous polymorphisms (raw count, mode-invariant)."""
+    ps_total: int = 0
+    """Total synonymous polymorphisms (raw count, mode-invariant)."""
+    sfs_mode: str = "at"
+    """SFS construction mode used to build ``pn_counts``/``ps_counts``."""
 
 
 @dataclass
@@ -128,6 +134,9 @@ class AsymptoticMKResult:
     """Method used to compute ``ci_low``/``ci_high``: ``"monte-carlo"`` samples
     parameters from the curve-fit covariance matrix; ``"bootstrap"`` resamples
     polymorphisms with replacement and refits per replicate."""
+    sfs_mode: str = "at"
+    """SFS construction mode: ``"at"`` (Messer & Petrov 2013, count per bin) or
+    ``"above"`` (Uricchio et al. 2019, inclusive right-tail cumulative count)."""
 
     # Dn, Ds, Ln, Ls are constants under the asymptotic Monte Carlo procedure,
     # so omega has no sampling distribution. The CIs on omega_a and omega_na
@@ -170,6 +179,7 @@ class AsymptoticMKResult:
             f"  Asymptotic α: {self.alpha_asymptotic:.4f} "
             f"(95% CI [{self.ci_method}]: {self.ci_low:.4f} - {self.ci_high:.4f})",
             f"  Divergence: Dn={self.dn}, Ds={self.ds}",
+            f"  SFS mode: {self.sfs_mode}",
         ]
         if self.pn_total > 0 or self.ps_total > 0:
             lines.append(f"  Polymorphism: Pn={self.pn_total}, Ps={self.ps_total}")
@@ -237,6 +247,7 @@ class AsymptoticMKResult:
         result["omega_na_ci_low"] = self.omega_na_ci_low
         result["omega_na_ci_high"] = self.omega_na_ci_high
         result["ci_method"] = self.ci_method
+        result["sfs_mode"] = self.sfs_mode
         return result
 
 
@@ -255,6 +266,27 @@ def _attach_omega(
     result.omega_a = omega_a
     result.omega_na = omega_na
     return result
+
+
+_SFS_MODES: tuple[str, ...] = ("at", "above")
+
+
+def _validate_sfs_mode(sfs_mode: str) -> None:
+    """Reject any value other than 'at' or 'above'."""
+    if sfs_mode not in _SFS_MODES:
+        raise ValueError(f"sfs_mode must be one of {_SFS_MODES!r}, got {sfs_mode!r}")
+
+
+def _apply_sfs_mode(pn: np.ndarray, ps: np.ndarray, sfs_mode: str) -> tuple[np.ndarray, np.ndarray]:
+    """Transform per-bin counts into the requested SFS form.
+
+    Under ``"at"`` mode the inputs are returned unchanged. Under ``"above"``
+    mode each is replaced by its inclusive right-tail cumulative sum so that
+    bin ``i`` holds the count in bins ``[i, end]`` (Uricchio et al. 2019).
+    """
+    if sfs_mode == "above":
+        return np.cumsum(pn[::-1])[::-1], np.cumsum(ps[::-1])[::-1]
+    return pn, ps
 
 
 def _exponential_model(x: np.ndarray, a: float, b: float, c: float) -> np.ndarray:
@@ -338,6 +370,7 @@ def _compute_ci_bootstrap(
     point_estimate: float,
     n_replicates: int = 100,
     seed: int = 42,
+    sfs_mode: str = "at",
 ) -> tuple[float, float]:
     """Compute CI by case-resampling the pooled polymorphism list.
 
@@ -369,8 +402,9 @@ def _compute_ci_bootstrap(
         sample = rng.integers(0, n, size=n)
         sample_bins = bin_idx[sample]
         sample_n = is_n[sample]
-        boot_pn = np.bincount(sample_bins[sample_n], minlength=num_bins)
-        boot_ps = np.bincount(sample_bins[~sample_n], minlength=num_bins)
+        boot_pn = np.bincount(sample_bins[sample_n], minlength=num_bins).astype(float)
+        boot_ps = np.bincount(sample_bins[~sample_n], minlength=num_bins).astype(float)
+        boot_pn, boot_ps = _apply_sfs_mode(boot_pn, boot_ps, sfs_mode)
 
         # Per-bin alpha where boot_ps > 0 and inside the fitting window.
         valid = (boot_ps > 0) & bin_in_window
@@ -545,16 +579,23 @@ def extract_polymorphism_data(
 def aggregate_polymorphism_data(
     gene_data: list[PolymorphismData],
     num_bins: int = 20,
+    sfs_mode: str = "at",
 ) -> AggregatedSFS:
     """Aggregate polymorphism data from multiple genes into SFS bins.
 
     Args:
         gene_data: List of PolymorphismData from individual genes
         num_bins: Number of frequency bins
+        sfs_mode: ``"at"`` (default, Messer & Petrov 2013) returns per-bin
+            counts. ``"above"`` (Uricchio et al. 2019) returns the inclusive
+            right-tail cumulative SFS — bin ``i`` holds the count of
+            polymorphisms with frequency ``>= bin_edges[i]``.
 
     Returns:
         AggregatedSFS with per-bin Pn/Ps counts and total divergence
     """
+    _validate_sfs_mode(sfs_mode)
+
     # Sum divergence across all genes
     dn_total = sum(g.dn for g in gene_data)
     ds_total = sum(g.ds for g in gene_data)
@@ -582,6 +623,11 @@ def aggregate_polymorphism_data(
         else:
             ps_counts[bin_idx] += 1
 
+    pn_total = int(pn_counts.sum())
+    ps_total = int(ps_counts.sum())
+
+    pn_counts, ps_counts = _apply_sfs_mode(pn_counts, ps_counts, sfs_mode)
+
     return AggregatedSFS(
         bin_edges=bin_edges,
         pn_counts=pn_counts,
@@ -591,6 +637,9 @@ def aggregate_polymorphism_data(
         num_genes=len(gene_data),
         ln_total=ln_total,
         ls_total=ls_total,
+        pn_total=pn_total,
+        ps_total=ps_total,
+        sfs_mode=sfs_mode,
     )
 
 
@@ -601,6 +650,7 @@ def asymptotic_mk_test_aggregated(
     frequency_cutoffs: tuple[float, float] = (0.1, 0.9),
     ci_method: str = "monte-carlo",
     seed: int = 42,
+    sfs_mode: str = "at",
 ) -> AsymptoticMKResult:
     """Genome-wide asymptotic MK test on aggregated data.
 
@@ -626,28 +676,29 @@ def asymptotic_mk_test_aggregated(
     """
     if ci_method not in ("monte-carlo", "bootstrap"):
         raise ValueError(f"ci_method must be 'monte-carlo' or 'bootstrap', got {ci_method!r}")
+    _validate_sfs_mode(sfs_mode)
 
     # Aggregate the data
-    agg = aggregate_polymorphism_data(gene_data, num_bins)
+    agg = aggregate_polymorphism_data(gene_data, num_bins, sfs_mode=sfs_mode)
 
     dn = agg.dn_total
     ds = agg.ds_total
     bin_edges = agg.bin_edges
     bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
 
-    # Calculate total polymorphisms
-    pn_total = int(np.sum(agg.pn_counts))
-    ps_total = int(np.sum(agg.ps_counts))
+    # Total polymorphisms (raw, mode-invariant — used for the simple-α fallback
+    # and for output reporting, never for the per-bin α(x) curve).
+    pn_total = agg.pn_total
+    ps_total = agg.ps_total
 
-    # Calculate per-bin alpha for each frequency bin (matching asymptoticMK R package)
-    # α(x) = 1 - (d0/d) * (p(x)/p0(x)) where p(x) and p0(x) are per-bin counts
+    # Calculate per-bin alpha for each frequency bin (matching asymptoticMK R package
+    # under "at" mode; under "above" mode this is α(>x) on the cumulative SFS).
     alpha_values = []
     valid_centers = []
 
     for i in range(num_bins):
-        # Per-bin counts (not cumulative)
-        pn_bin = int(agg.pn_counts[i])
-        ps_bin = int(agg.ps_counts[i])
+        pn_bin = float(agg.pn_counts[i])
+        ps_bin = float(agg.ps_counts[i])
 
         if ds > 0 and dn > 0 and ps_bin > 0:
             alpha_x = 1.0 - (ds / dn) * (pn_bin / ps_bin)
@@ -673,6 +724,7 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
             ci_method=ci_method,
+            sfs_mode=sfs_mode,
         )
         return _attach_omega(result, agg.ln_total, agg.ls_total)
 
@@ -798,6 +850,7 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
             ci_method=ci_method,
+            sfs_mode=sfs_mode,
         )
         return _attach_omega(result, agg.ln_total, agg.ls_total)
 
@@ -819,6 +872,7 @@ def asymptotic_mk_test_aggregated(
                 exp_alpha,
                 n_replicates=ci_replicates,
                 seed=seed,
+                sfs_mode=sfs_mode,
             )
         else:
             ci_low_lin, ci_high_lin = _compute_ci_bootstrap(
@@ -835,6 +889,7 @@ def asymptotic_mk_test_aggregated(
                 lin_alpha,
                 n_replicates=ci_replicates,
                 seed=seed,
+                sfs_mode=sfs_mode,
             )
 
     if use_exponential:
@@ -856,6 +911,7 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
             ci_method=ci_method,
+            sfs_mode=sfs_mode,
         )
     else:
         a_lin, b_lin = lin_popt
@@ -876,6 +932,7 @@ def asymptotic_mk_test_aggregated(
             pn_total=pn_total,
             ps_total=ps_total,
             ci_method=ci_method,
+            sfs_mode=sfs_mode,
         )
     return _attach_omega(result, agg.ln_total, agg.ls_total)
 
@@ -888,6 +945,7 @@ def asymptotic_mk_test(
     num_bins: int = 10,
     bootstrap_replicates: int = 100,
     pool_polymorphisms: bool = False,
+    sfs_mode: str = "at",
 ) -> AsymptoticMKResult:
     """Perform the asymptotic McDonald-Kreitman test.
 
@@ -912,6 +970,8 @@ def asymptotic_mk_test(
     Returns:
         AsymptoticMKResult containing test statistics
     """
+    _validate_sfs_mode(sfs_mode)
+
     code = genetic_code or DEFAULT_CODE
 
     # Load sequences if paths provided
@@ -990,8 +1050,8 @@ def asymptotic_mk_test(
     bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
 
     # Bin polymorphisms by derived allele frequency
-    pn_per_bin = [0] * num_bins
-    ps_per_bin = [0] * num_bins
+    pn_per_bin = np.zeros(num_bins)
+    ps_per_bin = np.zeros(num_bins)
 
     for freq, poly_type in poly_data:
         # Find which bin this frequency falls into
@@ -1002,15 +1062,17 @@ def asymptotic_mk_test(
         else:
             ps_per_bin[bin_idx] += 1
 
-    # Calculate per-bin alpha (matching asymptoticMK R package)
-    # α(x) = 1 - (d0/d) * (p(x)/p0(x)) where p(x) and p0(x) are per-bin counts
+    pn_per_bin, ps_per_bin = _apply_sfs_mode(pn_per_bin, ps_per_bin, sfs_mode)
+
+    # Calculate per-bin alpha (matching asymptoticMK R package under "at" mode;
+    # under "above" mode this is α(>x) on the cumulative SFS).
     alpha_values = []
     valid_bins = []
     valid_centers = []
 
     for i in range(num_bins):
-        pn_bin = pn_per_bin[i]
-        ps_bin = ps_per_bin[i]
+        pn_bin = float(pn_per_bin[i])
+        ps_bin = float(ps_per_bin[i])
 
         if ds > 0 and dn > 0 and ps_bin > 0:
             alpha_x = 1.0 - (ds / dn) * (pn_bin / ps_bin)
@@ -1037,6 +1099,7 @@ def asymptotic_mk_test(
             dn=dn,
             ds=ds,
             ci_method="bootstrap",
+            sfs_mode=sfs_mode,
         )
         return _attach_omega(result, ln_total, ls_total)
 
@@ -1087,6 +1150,7 @@ def asymptotic_mk_test(
         alpha_asymp,
         n_replicates=bootstrap_replicates,
         seed=42,
+        sfs_mode=sfs_mode,
     )
 
     result = AsymptoticMKResult(
@@ -1102,5 +1166,6 @@ def asymptotic_mk_test(
         dn=dn,
         ds=ds,
         ci_method="bootstrap",
+        sfs_mode=sfs_mode,
     )
     return _attach_omega(result, ln_total, ls_total)

--- a/src/mkado/analysis/statistics.py
+++ b/src/mkado/analysis/statistics.py
@@ -7,9 +7,7 @@ import math
 from scipy import stats
 
 
-def fishers_exact(
-    dn: int, ds: int, pn: int, ps: int, alternative: str = "two-sided"
-) -> float:
+def fishers_exact(dn: int, ds: int, pn: int, ps: int, alternative: str = "two-sided") -> float:
     """Perform Fisher's exact test on a 2x2 contingency table.
 
     The table is:

--- a/src/mkado/batch_workers.py
+++ b/src/mkado/batch_workers.py
@@ -76,6 +76,10 @@ class BatchTask:
     """CI method for aggregated asymptotic MK ("monte-carlo" or "bootstrap").
     Ignored for non-aggregated modes."""
 
+    sfs_mode: str = "at"
+    """Asymptotic-MK SFS construction: "at" (per-bin) or "above" (cumulative).
+    Ignored for non-asymptotic modes."""
+
 
 @dataclass
 class WorkerResult:
@@ -173,6 +177,7 @@ def process_gene(task: BatchTask) -> WorkerResult:
                     bootstrap_replicates=task.bootstrap,
                     pool_polymorphisms=task.pool_polymorphisms,
                     genetic_code=genetic_code,
+                    sfs_mode=task.sfs_mode,
                 )
                 return WorkerResult(gene_id=gene_id, result=result)
 
@@ -266,6 +271,7 @@ def process_gene(task: BatchTask) -> WorkerResult:
                     bootstrap_replicates=task.bootstrap,
                     pool_polymorphisms=task.pool_polymorphisms,
                     genetic_code=genetic_code,
+                    sfs_mode=task.sfs_mode,
                 )
                 return WorkerResult(gene_id=gene_id, result=result)
 

--- a/src/mkado/cli.py
+++ b/src/mkado/cli.py
@@ -71,12 +71,33 @@ CIMethodOption = Annotated[
     ),
 ]
 
+SfsModeOption = Annotated[
+    str,
+    typer.Option(
+        "--sfs-mode",
+        help="Asymptotic-MK SFS construction: 'at' (default, Messer & Petrov 2013, "
+        "per-bin counts) or 'above' (Uricchio et al. 2019, inclusive right-tail "
+        "cumulative counts). Both modes share the asymptote at x=1 but 'above' "
+        "is more sample-size-stable. Ignored when --asymptotic is not set.",
+    ),
+]
+
 
 def validate_ci_method(ci_method: str) -> None:
     """Reject any ``--ci-method`` value other than the two supported strings."""
     if ci_method not in ("monte-carlo", "bootstrap"):
         typer.echo(
             f"Error: Invalid --ci-method '{ci_method}'. Use 'monte-carlo' or 'bootstrap'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
+def validate_sfs_mode(sfs_mode: str) -> None:
+    """Reject any ``--sfs-mode`` value other than 'at' or 'above'."""
+    if sfs_mode not in ("at", "above"):
+        typer.echo(
+            f"Error: Invalid --sfs-mode '{sfs_mode}'. Use 'at' or 'above'.",
             err=True,
         )
         raise typer.Exit(1)
@@ -366,6 +387,7 @@ def test(
         typer.Option("--bootstrap", help="Bootstrap replicates for CI (asymptotic)"),
     ] = 100,
     ci_method: CIMethodOption = "monte-carlo",
+    sfs_mode: SfsModeOption = "at",
     # === Common options ===
     output_format: Annotated[
         str,
@@ -445,6 +467,7 @@ def test(
         raise typer.Exit(1)
 
     validate_ci_method(ci_method)
+    validate_sfs_mode(sfs_mode)
 
     # Validate option compatibility
     if use_asymptotic and min_freq > 0.0:
@@ -570,6 +593,7 @@ def test(
                 bootstrap_replicates=bootstrap,
                 pool_polymorphisms=pool_polymorphisms,
                 genetic_code=genetic_code,
+                sfs_mode=sfs_mode,
             )
         elif use_imputed:
             from mkado.analysis.asymptotic import extract_polymorphism_data
@@ -652,6 +676,7 @@ def test(
                 bootstrap_replicates=bootstrap,
                 pool_polymorphisms=pool_polymorphisms,
                 genetic_code=genetic_code,
+                sfs_mode=sfs_mode,
             )
         elif use_imputed:
             from mkado.analysis.asymptotic import extract_polymorphism_data
@@ -797,6 +822,7 @@ def batch(
         typer.Option("--bootstrap", help="Bootstrap replicates (asymptotic)"),
     ] = 100,
     ci_method: CIMethodOption = "monte-carlo",
+    sfs_mode: SfsModeOption = "at",
     freq_cutoffs: Annotated[
         str,
         typer.Option("--freq-cutoffs", help="Frequency range 'low,high' (asymptotic)"),
@@ -892,6 +918,7 @@ def batch(
         mkado batch genes/ --ingroup-pattern "*_in.fa" --outgroup-pattern "*_out.fa"
     """
     validate_ci_method(ci_method)
+    validate_sfs_mode(sfs_mode)
 
     if output_format not in ("pretty", "tsv", "json"):
         typer.echo(f"Error: Invalid format '{output_format}'.", err=True)
@@ -1024,6 +1051,7 @@ def batch(
                 or (use_imputed and aggregate),
                 code_table=code_table_id,
                 ci_method=ci_method,
+                sfs_mode=sfs_mode,
             )
             for f in alignment_files
         ]
@@ -1075,6 +1103,7 @@ def batch(
                     ci_replicates=ci_replicates,
                     frequency_cutoffs=frequency_cutoffs,
                     ci_method=ci_method,
+                    sfs_mode=sfs_mode,
                 )
                 write_output(format_result(result, fmt), output)
 
@@ -1205,6 +1234,7 @@ def batch(
                     or alpha_tg
                     or (use_imputed and aggregate),
                     code_table=code_table_id,
+                    sfs_mode=sfs_mode,
                 )
             )
 
@@ -1262,6 +1292,7 @@ def batch(
                     ci_replicates=ci_replicates,
                     frequency_cutoffs=frequency_cutoffs,
                     ci_method=ci_method,
+                    sfs_mode=sfs_mode,
                 )
                 write_output(format_result(result, fmt), output)
 
@@ -1448,6 +1479,7 @@ def vcf(
         typer.Option("--bootstrap", help="Bootstrap replicates"),
     ] = 100,
     ci_method: CIMethodOption = "monte-carlo",
+    sfs_mode: SfsModeOption = "at",
     freq_cutoffs: Annotated[
         str,
         typer.Option("--freq-cutoffs", help="Frequency range 'low,high' (asymptotic)"),
@@ -1533,6 +1565,7 @@ def vcf(
         raise typer.Exit(1)
 
     validate_ci_method(ci_method)
+    validate_sfs_mode(sfs_mode)
 
     # Validate file existence
     for path, name in [(vcf_file, "--vcf"), (ref, "--ref"), (gff, "--gff")]:
@@ -1646,6 +1679,7 @@ def vcf(
             imputed_cutoff=imputed_cutoff,
             extract_only=is_aggregate or (gene is None and not use_asymptotic and not use_imputed),
             ci_method=ci_method,
+            sfs_mode=sfs_mode,
         )
         for cds in cds_regions
     ]
@@ -1747,6 +1781,7 @@ def vcf(
                 ci_replicates=ci_replicates,
                 frequency_cutoffs=frequency_cutoffs,
                 ci_method=ci_method,
+                sfs_mode=sfs_mode,
             )
             write_output(format_result(result, fmt), output)
             if plot_asymptotic:

--- a/src/mkado/data/genetic_codes.py
+++ b/src/mkado/data/genetic_codes.py
@@ -10,98 +10,250 @@ from itertools import permutations
 
 # Standard genetic code (NCBI table 1)
 STANDARD_CODE: dict[str, str] = {
-    "TTT": "F", "TTC": "F", "TTA": "L", "TTG": "L",
-    "TCT": "S", "TCC": "S", "TCA": "S", "TCG": "S",
-    "TAT": "Y", "TAC": "Y", "TAA": "*", "TAG": "*",
-    "TGT": "C", "TGC": "C", "TGA": "*", "TGG": "W",
-    "CTT": "L", "CTC": "L", "CTA": "L", "CTG": "L",
-    "CCT": "P", "CCC": "P", "CCA": "P", "CCG": "P",
-    "CAT": "H", "CAC": "H", "CAA": "Q", "CAG": "Q",
-    "CGT": "R", "CGC": "R", "CGA": "R", "CGG": "R",
-    "ATT": "I", "ATC": "I", "ATA": "I", "ATG": "M",
-    "ACT": "T", "ACC": "T", "ACA": "T", "ACG": "T",
-    "AAT": "N", "AAC": "N", "AAA": "K", "AAG": "K",
-    "AGT": "S", "AGC": "S", "AGA": "R", "AGG": "R",
-    "GTT": "V", "GTC": "V", "GTA": "V", "GTG": "V",
-    "GCT": "A", "GCC": "A", "GCA": "A", "GCG": "A",
-    "GAT": "D", "GAC": "D", "GAA": "E", "GAG": "E",
-    "GGT": "G", "GGC": "G", "GGA": "G", "GGG": "G",
+    "TTT": "F",
+    "TTC": "F",
+    "TTA": "L",
+    "TTG": "L",
+    "TCT": "S",
+    "TCC": "S",
+    "TCA": "S",
+    "TCG": "S",
+    "TAT": "Y",
+    "TAC": "Y",
+    "TAA": "*",
+    "TAG": "*",
+    "TGT": "C",
+    "TGC": "C",
+    "TGA": "*",
+    "TGG": "W",
+    "CTT": "L",
+    "CTC": "L",
+    "CTA": "L",
+    "CTG": "L",
+    "CCT": "P",
+    "CCC": "P",
+    "CCA": "P",
+    "CCG": "P",
+    "CAT": "H",
+    "CAC": "H",
+    "CAA": "Q",
+    "CAG": "Q",
+    "CGT": "R",
+    "CGC": "R",
+    "CGA": "R",
+    "CGG": "R",
+    "ATT": "I",
+    "ATC": "I",
+    "ATA": "I",
+    "ATG": "M",
+    "ACT": "T",
+    "ACC": "T",
+    "ACA": "T",
+    "ACG": "T",
+    "AAT": "N",
+    "AAC": "N",
+    "AAA": "K",
+    "AAG": "K",
+    "AGT": "S",
+    "AGC": "S",
+    "AGA": "R",
+    "AGG": "R",
+    "GTT": "V",
+    "GTC": "V",
+    "GTA": "V",
+    "GTG": "V",
+    "GCT": "A",
+    "GCC": "A",
+    "GCA": "A",
+    "GCG": "A",
+    "GAT": "D",
+    "GAC": "D",
+    "GAA": "E",
+    "GAG": "E",
+    "GGT": "G",
+    "GGC": "G",
+    "GGA": "G",
+    "GGG": "G",
 }
 
 # NCBI genetic code tables
 # Each table is defined by its differences from the standard code.
 # Format: {table_id: (name, {codon: amino_acid, ...})}
 _CODE_DIFFS: dict[int, tuple[str, dict[str, str]]] = {
-    2: ("Vertebrate Mitochondrial", {
-        "AGA": "*", "AGG": "*", "ATA": "M", "TGA": "W",
-    }),
-    3: ("Yeast Mitochondrial", {
-        "ATA": "M", "CTT": "T", "CTC": "T", "CTA": "T", "CTG": "T",
-        "TGA": "W",
-    }),
-    4: ("Mold, Protozoan, Coelenterate Mitochondrial; Mycoplasma; Spiroplasma", {
-        "TGA": "W",
-    }),
-    5: ("Invertebrate Mitochondrial", {
-        "AGA": "S", "AGG": "S", "ATA": "M", "TGA": "W",
-    }),
-    6: ("Ciliate, Dasycladacean and Hexamita Nuclear", {
-        "TAA": "Q", "TAG": "Q",
-    }),
-    9: ("Echinoderm and Flatworm Mitochondrial", {
-        "AAA": "N", "AGA": "S", "AGG": "S", "TGA": "W",
-    }),
-    10: ("Euplotid Nuclear", {
-        "TGA": "C",
-    }),
-    11: ("Bacterial, Archaeal and Plant Plastid", {
-        # Identical to standard code for amino acid assignments
-    }),
-    12: ("Alternative Yeast Nuclear", {
-        "CTG": "S",
-    }),
-    13: ("Ascidian Mitochondrial", {
-        "AGA": "G", "AGG": "G", "ATA": "M", "TGA": "W",
-    }),
-    14: ("Alternative Flatworm Mitochondrial", {
-        "AAA": "N", "AGA": "S", "AGG": "S", "TAA": "Y", "TGA": "W",
-    }),
-    16: ("Chlorophycean Mitochondrial", {
-        "TAG": "L",
-    }),
-    21: ("Trematode Mitochondrial", {
-        "AAA": "N", "AGA": "S", "AGG": "S", "ATA": "M", "TGA": "W",
-    }),
-    22: ("Scenedesmus obliquus Mitochondrial", {
-        "TAG": "L", "TCA": "*",
-    }),
-    23: ("Thraustochytrium Mitochondrial", {
-        "TTA": "*",
-    }),
-    24: ("Rhabdopleuridae Mitochondrial", {
-        "AGA": "S", "AGG": "K", "TGA": "W",
-    }),
-    25: ("Candidate Division SR1 and Gracilibacteria", {
-        "TGA": "G",
-    }),
-    26: ("Pachysolen tannophilus Nuclear", {
-        "CTG": "A",
-    }),
-    27: ("Karyorelictea Nuclear", {
-        "TAA": "Q", "TAG": "Q", "TGA": "W",
-    }),
-    29: ("Mesodinium Nuclear", {
-        "TAA": "Y", "TAG": "Y",
-    }),
-    30: ("Peritrich Nuclear", {
-        "TAA": "E", "TAG": "E",
-    }),
-    31: ("Blastocrithidia Nuclear", {
-        "TGA": "W",
-    }),
-    33: ("Cephalodiscidae Mitochondrial UAA-Tyr", {
-        "AGA": "S", "AGG": "K", "TAA": "Y", "TGA": "W",
-    }),
+    2: (
+        "Vertebrate Mitochondrial",
+        {
+            "AGA": "*",
+            "AGG": "*",
+            "ATA": "M",
+            "TGA": "W",
+        },
+    ),
+    3: (
+        "Yeast Mitochondrial",
+        {
+            "ATA": "M",
+            "CTT": "T",
+            "CTC": "T",
+            "CTA": "T",
+            "CTG": "T",
+            "TGA": "W",
+        },
+    ),
+    4: (
+        "Mold, Protozoan, Coelenterate Mitochondrial; Mycoplasma; Spiroplasma",
+        {
+            "TGA": "W",
+        },
+    ),
+    5: (
+        "Invertebrate Mitochondrial",
+        {
+            "AGA": "S",
+            "AGG": "S",
+            "ATA": "M",
+            "TGA": "W",
+        },
+    ),
+    6: (
+        "Ciliate, Dasycladacean and Hexamita Nuclear",
+        {
+            "TAA": "Q",
+            "TAG": "Q",
+        },
+    ),
+    9: (
+        "Echinoderm and Flatworm Mitochondrial",
+        {
+            "AAA": "N",
+            "AGA": "S",
+            "AGG": "S",
+            "TGA": "W",
+        },
+    ),
+    10: (
+        "Euplotid Nuclear",
+        {
+            "TGA": "C",
+        },
+    ),
+    11: (
+        "Bacterial, Archaeal and Plant Plastid",
+        {
+            # Identical to standard code for amino acid assignments
+        },
+    ),
+    12: (
+        "Alternative Yeast Nuclear",
+        {
+            "CTG": "S",
+        },
+    ),
+    13: (
+        "Ascidian Mitochondrial",
+        {
+            "AGA": "G",
+            "AGG": "G",
+            "ATA": "M",
+            "TGA": "W",
+        },
+    ),
+    14: (
+        "Alternative Flatworm Mitochondrial",
+        {
+            "AAA": "N",
+            "AGA": "S",
+            "AGG": "S",
+            "TAA": "Y",
+            "TGA": "W",
+        },
+    ),
+    16: (
+        "Chlorophycean Mitochondrial",
+        {
+            "TAG": "L",
+        },
+    ),
+    21: (
+        "Trematode Mitochondrial",
+        {
+            "AAA": "N",
+            "AGA": "S",
+            "AGG": "S",
+            "ATA": "M",
+            "TGA": "W",
+        },
+    ),
+    22: (
+        "Scenedesmus obliquus Mitochondrial",
+        {
+            "TAG": "L",
+            "TCA": "*",
+        },
+    ),
+    23: (
+        "Thraustochytrium Mitochondrial",
+        {
+            "TTA": "*",
+        },
+    ),
+    24: (
+        "Rhabdopleuridae Mitochondrial",
+        {
+            "AGA": "S",
+            "AGG": "K",
+            "TGA": "W",
+        },
+    ),
+    25: (
+        "Candidate Division SR1 and Gracilibacteria",
+        {
+            "TGA": "G",
+        },
+    ),
+    26: (
+        "Pachysolen tannophilus Nuclear",
+        {
+            "CTG": "A",
+        },
+    ),
+    27: (
+        "Karyorelictea Nuclear",
+        {
+            "TAA": "Q",
+            "TAG": "Q",
+            "TGA": "W",
+        },
+    ),
+    29: (
+        "Mesodinium Nuclear",
+        {
+            "TAA": "Y",
+            "TAG": "Y",
+        },
+    ),
+    30: (
+        "Peritrich Nuclear",
+        {
+            "TAA": "E",
+            "TAG": "E",
+        },
+    ),
+    31: (
+        "Blastocrithidia Nuclear",
+        {
+            "TGA": "W",
+        },
+    ),
+    33: (
+        "Cephalodiscidae Mitochondrial UAA-Tyr",
+        {
+            "AGA": "S",
+            "AGG": "K",
+            "TAA": "Y",
+            "TGA": "W",
+        },
+    ),
 }
 
 
@@ -159,8 +311,7 @@ def resolve_code_table(name_or_id: str) -> int:
         if table_id == 1 or table_id in _CODE_DIFFS:
             return table_id
         raise ValueError(
-            f"Unknown genetic code table {table_id}. "
-            f"Run 'mkado codes' to see available tables."
+            f"Unknown genetic code table {table_id}. Run 'mkado codes' to see available tables."
         )
 
     # Try name alias
@@ -169,8 +320,7 @@ def resolve_code_table(name_or_id: str) -> int:
         return _CODE_ALIASES[key]
 
     raise ValueError(
-        f"Unknown genetic code '{name_or_id}'. "
-        f"Run 'mkado codes' to see available tables."
+        f"Unknown genetic code '{name_or_id}'. Run 'mkado codes' to see available tables."
     )
 
 
@@ -210,9 +360,7 @@ def available_code_tables() -> list[tuple[int, str, list[str]]]:
     for alias, tid in _CODE_ALIASES.items():
         aliases_by_id.setdefault(tid, []).append(alias)
 
-    tables: list[tuple[int, str, list[str]]] = [
-        (1, "Standard", aliases_by_id.get(1, []))
-    ]
+    tables: list[tuple[int, str, list[str]]] = [(1, "Standard", aliases_by_id.get(1, []))]
     for table_id in sorted(_CODE_DIFFS.keys()):
         tables.append((table_id, _CODE_DIFFS[table_id][0], aliases_by_id.get(table_id, [])))
     return tables

--- a/src/mkado/io/output.py
+++ b/src/mkado/io/output.py
@@ -150,7 +150,11 @@ def _format_tsv(
         return "\n".join(lines)
 
     elif isinstance(result, AsymptoticMKResult):
-        ci_cols = "\tomega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
+        ci_cols = (
+            "\tomega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high"
+            "\tci_method\tsfs_mode"
+        )
+        ci_values = f"{result.ci_method}\t{result.sfs_mode}"
         if result.num_genes > 0:
             # Aggregated result
             header = (
@@ -162,7 +166,7 @@ def _format_tsv(
                 f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
                 f"{result.model_type}\t{result.num_genes}\t"
                 f"{_omega_full_tsv_columns(result)}\t"
-                f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
+                f"{_omega_a_na_ci_tsv_columns(result)}\t{ci_values}"
             )
         else:
             header = (
@@ -173,7 +177,7 @@ def _format_tsv(
                 f"{result.dn}\t{result.ds}\t{result.alpha_asymptotic:.6f}\t"
                 f"{result.ci_low:.6f}\t{result.ci_high:.6f}\t"
                 f"{_omega_full_tsv_columns(result)}\t"
-                f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
+                f"{_omega_a_na_ci_tsv_columns(result)}\t{ci_values}"
             )
         return f"{header}\n{values}"
 
@@ -270,7 +274,8 @@ def format_batch_results(
             header = (
                 "gene\tDn\tDs\talpha_asymptotic\tCI_low\tCI_high\tmodel\t"
                 "Ln\tLs\tomega\tomega_a\tomega_na\t"
-                "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\tci_method"
+                "omega_a_CI_low\tomega_a_CI_high\tomega_na_CI_low\tomega_na_CI_high\t"
+                "ci_method\tsfs_mode"
             )
             lines = [header]
             for name, result in results:
@@ -280,7 +285,8 @@ def format_batch_results(
                         f"{result.alpha_asymptotic:.6f}\t{result.ci_low:.6f}\t"
                         f"{result.ci_high:.6f}\t{result.model_type}\t"
                         f"{_omega_full_tsv_columns(result)}\t"
-                        f"{_omega_a_na_ci_tsv_columns(result)}\t{result.ci_method}"
+                        f"{_omega_a_na_ci_tsv_columns(result)}\t"
+                        f"{result.ci_method}\t{result.sfs_mode}"
                     )
             return "\n".join(lines)
 

--- a/src/mkado/io/plotting.py
+++ b/src/mkado/io/plotting.py
@@ -161,7 +161,6 @@ def create_volcano_plot(
     ax.set_xlabel("-log$_{10}$(NI)", fontsize=12)
     ax.set_ylabel("-log$_{10}$(p-value)", fontsize=12)
 
-
     # Add legend
     ax.legend(loc="upper right", framealpha=0.9)
 
@@ -213,9 +212,7 @@ def create_asymptotic_plot(
         raise ValueError("No frequency bin data available for plotting")
 
     if len(x_data) != len(y_data):
-        raise ValueError(
-            f"Mismatched data: {len(x_data)} x values vs {len(y_data)} alpha values"
-        )
+        raise ValueError(f"Mismatched data: {len(x_data)} x values vs {len(y_data)} alpha values")
 
     # Create figure
     fig, ax = plt.subplots(figsize=(10, 8))
@@ -272,10 +269,14 @@ def create_asymptotic_plot(
         label=fit_label,
     )
 
-    # Labels and title
+    # Labels and title — Uricchio et al. 2019 cumulative SFS uses α(>x) instead.
     ax.set_xlabel("Derived allele frequency x", fontsize=12)
-    ax.set_ylabel("MK α(x)", fontsize=12)
-    ax.set_title("Asymptotic MK Test: α(x) vs Frequency", fontsize=14, fontweight="bold")
+    if result.sfs_mode == "above":
+        ax.set_ylabel("MK α(>x)", fontsize=12)
+        ax.set_title("Asymptotic MK Test: α(>x) vs Frequency", fontsize=14, fontweight="bold")
+    else:
+        ax.set_ylabel("MK α(x)", fontsize=12)
+        ax.set_title("Asymptotic MK Test: α(x) vs Frequency", fontsize=14, fontweight="bold")
 
     # Set axis limits
     ax.set_xlim(0, 1)

--- a/src/mkado/io/vcf.py
+++ b/src/mkado/io/vcf.py
@@ -140,9 +140,7 @@ def _query_ingroup_snps_with_handle(
                 warnings.simplefilter("ignore")
                 variants = list(vcf(region))
         except Exception as exc:
-            logger.debug(
-                "ingroup VCF query failed for %s region %s: %s", cds.gene_id, region, exc
-            )
+            logger.debug("ingroup VCF query failed for %s region %s: %s", cds.gene_id, region, exc)
             continue
 
         for variant in variants:
@@ -238,9 +236,7 @@ def _query_outgroup_genotype_with_handle(
                 warnings.simplefilter("ignore")
                 variants = list(vcf(region))
         except Exception as exc:
-            logger.debug(
-                "outgroup VCF query failed for %s region %s: %s", cds.gene_id, region, exc
-            )
+            logger.debug("outgroup VCF query failed for %s region %s: %s", cds.gene_id, region, exc)
             continue
 
         for variant in variants:

--- a/src/mkado/vcf_workers.py
+++ b/src/mkado/vcf_workers.py
@@ -38,6 +38,7 @@ class VcfBatchTask:
     imputed_cutoff: float = 0.15
     extract_only: bool = False
     ci_method: str = "monte-carlo"
+    sfs_mode: str = "at"
 
 
 @dataclass
@@ -120,6 +121,7 @@ def _process_single_gene(
                 num_bins=task.bins,
                 ci_replicates=ci_replicates,
                 ci_method=task.ci_method,
+                sfs_mode=task.sfs_mode,
             )
             return WorkerResult(gene_id=task.gene_id, result=result, warning=warning)
 
@@ -252,6 +254,7 @@ def process_vcf_gene(task: VcfBatchTask) -> WorkerResult:
                 num_bins=task.bins,
                 ci_replicates=ci_replicates,
                 ci_method=task.ci_method,
+                sfs_mode=task.sfs_mode,
             )
             return WorkerResult(gene_id=task.gene_id, result=result, warning=warning)
 

--- a/tests/test_asymptotic.py
+++ b/tests/test_asymptotic.py
@@ -636,3 +636,116 @@ class TestBootstrapCiCoverage:
             f"Bootstrap CI coverage {coverage:.2f} outside expected range; "
             f"true α(1)={true_alpha_at_1:.4f}"
         )
+
+
+class TestSfsMode:
+    """Tests for the --sfs-mode flag (Uricchio et al. 2019 cumulative SFS).
+
+    The cumulative ("above x") form replaces per-bin counts with an inclusive
+    suffix sum: bin i = count of polymorphisms with derived frequency
+    >= bin_edges[i]. The asymptote at x→1 is the same as the at-x form, but
+    the curve is smoother and more sample-size-stable.
+    """
+
+    def test_aggregate_default_sfs_mode_is_at(self) -> None:
+        """No sfs_mode argument keeps the existing per-bin (at-x) counts."""
+        gene_data = [
+            PolymorphismData(
+                polymorphisms=[(0.2, "N"), (0.5, "S"), (0.8, "N")],
+                dn=5,
+                ds=10,
+            )
+        ]
+        agg_default = aggregate_polymorphism_data(gene_data, num_bins=10)
+        agg_at = aggregate_polymorphism_data(gene_data, num_bins=10, sfs_mode="at")
+        np.testing.assert_array_equal(agg_default.pn_counts, agg_at.pn_counts)
+        np.testing.assert_array_equal(agg_default.ps_counts, agg_at.ps_counts)
+
+    def test_aggregate_sfs_mode_above_is_cumulative_suffix_sum(self) -> None:
+        """sfs_mode='above' produces an inclusive right-tail cumulative SFS.
+
+        With 10 bins of width 0.1, polymorphisms at frequencies 0.15, 0.45, 0.85
+        fall in bins 1, 4, 8 respectively. After cumulative transform, bin i
+        holds the count of polymorphisms in bins [i, end].
+        """
+        gene_data = [
+            PolymorphismData(
+                polymorphisms=[(0.15, "N"), (0.45, "N"), (0.85, "N")],
+                dn=5,
+                ds=10,
+            )
+        ]
+        agg = aggregate_polymorphism_data(gene_data, num_bins=10, sfs_mode="above")
+        # Bin 0 holds total count (>= 0.0); bins ramp down monotonically.
+        expected_pn = np.array([3, 3, 2, 2, 2, 1, 1, 1, 1, 0], dtype=float)
+        np.testing.assert_array_equal(agg.pn_counts, expected_pn)
+        # Monotonically non-increasing.
+        diffs = np.diff(agg.pn_counts)
+        assert np.all(diffs <= 0)
+
+    def test_aggregate_sfs_mode_invalid_raises(self) -> None:
+        """Any value other than 'at' or 'above' is rejected at the API."""
+        gene_data = [PolymorphismData(polymorphisms=[(0.2, "N")], dn=1, ds=1)]
+        with pytest.raises(ValueError):
+            aggregate_polymorphism_data(gene_data, num_bins=10, sfs_mode="bogus")
+
+    def test_asymptotic_aggregated_both_modes_converge_to_same_asymptote(self) -> None:
+        """The headline acceptance criterion: shared asymptote across modes.
+
+        The two SFS conventions are mathematically guaranteed to share α(1).
+        On a clean simulated dataset the fitted asymptotes must agree within
+        a generous tolerance, and each mode's own CI must bracket its own
+        point estimate. We do not require the narrower "above" CI to contain
+        the noisier "at" point estimate — the cumulative SFS legitimately
+        produces tighter CIs by averaging out per-bin noise.
+        """
+        gene_data = _make_aggregated_gene_data(num_genes=30, seed=7)
+        r_at = asymptotic_mk_test_aggregated(gene_data, num_bins=10, sfs_mode="at", seed=42)
+        r_above = asymptotic_mk_test_aggregated(gene_data, num_bins=10, sfs_mode="above", seed=42)
+        assert abs(r_at.alpha_asymptotic - r_above.alpha_asymptotic) < 0.1
+        assert r_at.ci_low <= r_at.alpha_asymptotic <= r_at.ci_high
+        assert r_above.ci_low <= r_above.alpha_asymptotic <= r_above.ci_high
+
+    def test_asymptotic_aggregated_records_sfs_mode(self) -> None:
+        """The result dataclass records which mode was used."""
+        gene_data = _make_aggregated_gene_data(num_genes=10, seed=8)
+        r_default = asymptotic_mk_test_aggregated(gene_data, num_bins=10)
+        r_above = asymptotic_mk_test_aggregated(gene_data, num_bins=10, sfs_mode="above")
+        assert r_default.sfs_mode == "at"
+        assert r_above.sfs_mode == "above"
+        assert r_default.to_dict()["sfs_mode"] == "at"
+        assert r_above.to_dict()["sfs_mode"] == "above"
+
+    def test_asymptotic_mk_test_single_gene_threads_sfs_mode(self, tmp_path: Path) -> None:
+        """The single-gene entry point also accepts and records sfs_mode."""
+        ingroup = tmp_path / "in.fa"
+        ingroup.write_text(
+            ">seq1\nATGTTTGCAGCAGCAGCAGCAGCA\n"
+            ">seq2\nATGTTCGCAGCAGCAGCAGCAGCA\n"
+            ">seq3\nATGTTTGCAGCAGCAGCAGCAGCA\n"
+            ">seq4\nATGTTAGCAGCAGCAGCAGCAGCA\n"
+            ">seq5\nATGTTTGCAGCAGCAGCAGCAGCA\n"
+        )
+        outgroup = tmp_path / "out.fa"
+        outgroup.write_text(">out\nATGTTGGCAGCAGCAGCAGCAGCA\n")
+
+        result = asymptotic_mk_test(
+            ingroup=ingroup, outgroup=outgroup, num_bins=5, sfs_mode="above"
+        )
+        assert result.sfs_mode == "above"
+
+    def test_bootstrap_ci_respects_sfs_mode(self) -> None:
+        """The bootstrap CI rebins resampled data using the same mode as the fit."""
+        gene_data = _make_aggregated_gene_data(num_genes=30, seed=9)
+        result = asymptotic_mk_test_aggregated(
+            gene_data,
+            num_bins=10,
+            sfs_mode="above",
+            ci_method="bootstrap",
+            ci_replicates=200,
+            seed=42,
+        )
+        assert result.sfs_mode == "above"
+        assert result.ci_method == "bootstrap"
+        assert result.ci_low <= result.ci_high
+        assert result.ci_low <= result.alpha_asymptotic <= result.ci_high

--- a/tests/test_cds.py
+++ b/tests/test_cds.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from mkado.core.cds import CdsRegion
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 from typer.testing import CliRunner
 
 from mkado.cli import app
@@ -28,10 +27,13 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--asymptotic",
-                "--min-freq", "0.1",
+                "--min-freq",
+                "0.1",
             ],
         )
 
@@ -58,10 +60,13 @@ ATGGTGATGATGATGATG
             [
                 "batch",
                 str(alignment_dir),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--alpha-tg",
-                "--min-freq", "0.1",
+                "--min-freq",
+                "0.1",
             ],
         )
 
@@ -84,8 +89,10 @@ ATGGTGATG
             [
                 "batch",
                 str(alignment_dir),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--alpha-tg",
                 "--asymptotic",
             ],
@@ -110,10 +117,13 @@ ATGATGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--asymptotic",
-                "--polarize-match", "speciesC",
+                "--polarize-match",
+                "speciesC",
             ],
         )
 
@@ -136,8 +146,10 @@ ATGGTGATGATGATGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--asymptotic",
             ],
         )
@@ -161,9 +173,12 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
-                "--min-freq", "0.1",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--min-freq",
+                "0.1",
             ],
         )
 
@@ -192,10 +207,13 @@ ATGATGATG
             [
                 "batch",
                 str(alignment_dir),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--asymptotic",
-                "--polarize-match", "speciesC",
+                "--polarize-match",
+                "speciesC",
             ],
         )
 
@@ -220,10 +238,13 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--no-singletons",
-                "--min-freq", "0.1",
+                "--min-freq",
+                "0.1",
             ],
         )
 
@@ -244,8 +265,10 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--no-singletons",
                 "--asymptotic",
             ],
@@ -270,8 +293,10 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--no-singletons",
             ],
         )
@@ -299,8 +324,10 @@ ATGGTGATGATGATGATG
             [
                 "batch",
                 str(alignment_dir),
-                "-i", "speciesA",
-                "-o", "speciesB",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
                 "--no-singletons",
                 "--alpha-tg",
             ],
@@ -337,9 +364,12 @@ ATGGTGATGATGATGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
-                "--code-table", "vertebrate-mito",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--code-table",
+                "vertebrate-mito",
             ],
         )
         assert result.exit_code == 0
@@ -360,9 +390,12 @@ ATGGTGATGATGATGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
-                "--code-table", "2",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--code-table",
+                "2",
             ],
         )
         assert result.exit_code == 0
@@ -381,9 +414,12 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
-                "--code-table", "not-a-real-code",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--code-table",
+                "not-a-real-code",
             ],
         )
         assert result.exit_code == 1
@@ -403,30 +439,37 @@ ATGGTGATG
             [
                 "test",
                 str(fasta),
-                "-i", "speciesA",
-                "-o", "speciesB",
-                "--code-table", "99",
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--code-table",
+                "99",
             ],
         )
         assert result.exit_code == 1
         assert "Unknown genetic code" in result.output
 
 
+def _make_asymptotic_alignment_dir(tmp_path: Path) -> Path:
+    """Build a tiny multi-gene alignment dir suitable for batch -a."""
+    alignment_dir = tmp_path / "alignments"
+    alignment_dir.mkdir()
+    # Three genes; each has a couple of polymorphisms across frequency
+    for i, codons in enumerate(["ATGTTT", "ATGTTC", "ATGTTA"]):
+        fa = alignment_dir / f"gene{i}.fa"
+        fa.write_text(
+            f">speciesA_1\n{codons}\n>speciesA_2\nATG{codons[3:]}\n"
+            f">speciesA_3\n{codons}\n>speciesB_1\nATGTTG\n"
+        )
+    return alignment_dir
+
+
 class TestCiMethodOption:
     """Tests for --ci-method flag."""
 
     def _make_alignment_dir(self, tmp_path: Path) -> Path:
-        """Build a tiny multi-gene alignment dir suitable for batch -a."""
-        alignment_dir = tmp_path / "alignments"
-        alignment_dir.mkdir()
-        # Three genes; each has a couple of polymorphisms across frequency
-        for i, codons in enumerate(["ATGTTT", "ATGTTC", "ATGTTA"]):
-            fa = alignment_dir / f"gene{i}.fa"
-            fa.write_text(
-                f">speciesA_1\n{codons}\n>speciesA_2\nATG{codons[3:]}\n"
-                f">speciesA_3\n{codons}\n>speciesB_1\nATGTTG\n"
-            )
-        return alignment_dir
+        return _make_asymptotic_alignment_dir(tmp_path)
 
     def test_invalid_ci_method_rejected_in_test(self, tmp_path: Path) -> None:
         fasta = tmp_path / "test.fa"
@@ -442,8 +485,16 @@ class TestCiMethodOption:
         alignment_dir = self._make_alignment_dir(tmp_path)
         result = runner.invoke(
             app,
-            ["batch", str(alignment_dir), "-i", "speciesA", "-o", "speciesB",
-             "--ci-method", "bogus"],
+            [
+                "batch",
+                str(alignment_dir),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--ci-method",
+                "bogus",
+            ],
         )
         assert result.exit_code == 1
         assert "Invalid --ci-method" in result.output
@@ -453,8 +504,17 @@ class TestCiMethodOption:
         alignment_dir = self._make_alignment_dir(tmp_path)
         result = runner.invoke(
             app,
-            ["batch", str(alignment_dir), "-i", "speciesA", "-o", "speciesB",
-             "--asymptotic", "--format", "tsv"],
+            [
+                "batch",
+                str(alignment_dir),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--format",
+                "tsv",
+            ],
         )
         assert result.exit_code == 0
         assert "ci_method" in result.output
@@ -464,10 +524,141 @@ class TestCiMethodOption:
         alignment_dir = self._make_alignment_dir(tmp_path)
         result = runner.invoke(
             app,
-            ["batch", str(alignment_dir), "-i", "speciesA", "-o", "speciesB",
-             "--asymptotic", "--ci-method", "bootstrap", "--bootstrap", "20",
-             "--format", "tsv"],
+            [
+                "batch",
+                str(alignment_dir),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--ci-method",
+                "bootstrap",
+                "--bootstrap",
+                "20",
+                "--format",
+                "tsv",
+            ],
         )
         assert result.exit_code == 0
         assert "ci_method" in result.output
         assert "bootstrap" in result.output
+
+
+class TestSfsModeOption:
+    """Tests for the --sfs-mode flag (Uricchio et al. 2019 cumulative SFS)."""
+
+    def _make_alignment_dir(self, tmp_path: Path) -> Path:
+        return _make_asymptotic_alignment_dir(tmp_path)
+
+    def test_invalid_sfs_mode_rejected_in_test(self, tmp_path: Path) -> None:
+        fasta = tmp_path / "test.fa"
+        fasta.write_text(">speciesA_1\nATGATGATG\n>speciesB_1\nATGGTGATG\n")
+        result = runner.invoke(
+            app,
+            [
+                "test",
+                str(fasta),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--sfs-mode",
+                "bogus",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Invalid --sfs-mode" in result.output
+
+    def test_invalid_sfs_mode_rejected_in_batch(self, tmp_path: Path) -> None:
+        alignment_dir = self._make_alignment_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "batch",
+                str(alignment_dir),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--sfs-mode",
+                "bogus",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Invalid --sfs-mode" in result.output
+
+    def test_sfs_mode_default_is_at_in_tsv(self, tmp_path: Path) -> None:
+        """Default --sfs-mode produces sfs_mode=at in batch -a output."""
+        alignment_dir = self._make_alignment_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "batch",
+                str(alignment_dir),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--format",
+                "tsv",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "sfs_mode" in result.output
+        assert "at" in result.output
+
+    def test_sfs_mode_above_appears_in_tsv(self, tmp_path: Path) -> None:
+        alignment_dir = self._make_alignment_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "batch",
+                str(alignment_dir),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--sfs-mode",
+                "above",
+                "--format",
+                "tsv",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "sfs_mode" in result.output
+        assert "above" in result.output
+
+    def test_sfs_mode_above_in_test_command_succeeds(self, tmp_path: Path) -> None:
+        fasta = tmp_path / "test.fa"
+        fasta.write_text(
+            ">speciesA_1\nATGTTTGCAGCAGCAGCAGCAGCA\n"
+            ">speciesA_2\nATGTTCGCAGCAGCAGCAGCAGCA\n"
+            ">speciesA_3\nATGTTAGCAGCAGCAGCAGCAGCA\n"
+            ">speciesA_4\nATGTTTGCAGCAGCAGCAGCAGCA\n"
+            ">speciesA_5\nATGTTGGCAGCAGCAGCAGCAGCA\n"
+            ">speciesB_1\nATGCTGGCAGCAGCAGCAGCAGCA\n"
+        )
+        result = runner.invoke(
+            app,
+            [
+                "test",
+                str(fasta),
+                "-i",
+                "speciesA",
+                "-o",
+                "speciesB",
+                "--asymptotic",
+                "--sfs-mode",
+                "above",
+                "--format",
+                "tsv",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "sfs_mode" in result.output
+        assert "above" in result.output

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 
 from mkado.io.fasta import read_fasta, write_fasta
 

--- a/tests/test_gff.py
+++ b/tests/test_gff.py
@@ -324,7 +324,9 @@ def test_malformed_lines_skipped(tmp_path: Path, caplog):
     assert len(regions) == 1
     assert regions[0].gene_id == "gene1"
     # Should warn about malformed lines
-    assert any("malformed" in msg.lower() or "skipping line" in msg.lower() for msg in caplog.messages)
+    assert any(
+        "malformed" in msg.lower() or "skipping line" in msg.lower() for msg in caplog.messages
+    )
 
 
 def test_non_integer_coordinates(tmp_path: Path, caplog):
@@ -640,15 +642,15 @@ def test_orphan_cds_warning_broken_ids(tmp_path: Path, caplog):
     # 3 properly structured genes
     for i in range(1, 4):
         s = i * 100
-        lines.append(f"chr1\t.\tgene\t{s}\t{s+8}\t.\t+\t.\tID=gene{i}")
-        lines.append(f"chr1\t.\tmRNA\t{s}\t{s+8}\t.\t+\t.\tID=tx{i};Parent=gene{i}")
-        lines.append(f"chr1\t.\tCDS\t{s}\t{s+8}\t.\t+\t0\tID=cds{i};Parent=tx{i}")
+        lines.append(f"chr1\t.\tgene\t{s}\t{s + 8}\t.\t+\t.\tID=gene{i}")
+        lines.append(f"chr1\t.\tmRNA\t{s}\t{s + 8}\t.\t+\t.\tID=tx{i};Parent=gene{i}")
+        lines.append(f"chr1\t.\tCDS\t{s}\t{s + 8}\t.\t+\t0\tID=cds{i};Parent=tx{i}")
     # 5 genes where mRNA has no ID — CDS parent won't resolve
     for i in range(4, 9):
         s = i * 100
-        lines.append(f"chr1\t.\tgene\t{s}\t{s+8}\t.\t+\t.\tID=gene{i}")
-        lines.append(f"chr1\t.\tmRNA\t{s}\t{s+8}\t.\t+\t.\tParent=gene{i}")
-        lines.append(f"chr1\t.\tCDS\t{s}\t{s+8}\t.\t+\t0\tID=cds{i};Parent=orphan_tx{i}")
+        lines.append(f"chr1\t.\tgene\t{s}\t{s + 8}\t.\t+\t.\tID=gene{i}")
+        lines.append(f"chr1\t.\tmRNA\t{s}\t{s + 8}\t.\t+\t.\tParent=gene{i}")
+        lines.append(f"chr1\t.\tCDS\t{s}\t{s + 8}\t.\t+\t0\tID=cds{i};Parent=orphan_tx{i}")
 
     gff_path = tmp_path / "broken_ids.gff3"
     gff_path.write_text("\n".join(lines) + "\n")

--- a/tests/test_mk_test.py
+++ b/tests/test_mk_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from mkado.analysis.mk_test import MKResult, mk_test, mk_test_from_counts
+from mkado.analysis.mk_test import mk_test, mk_test_from_counts
 from mkado.analysis.statistics import alpha, dos, fishers_exact, neutrality_index
 from mkado.core.sequences import SequenceSet
 
@@ -329,20 +329,19 @@ ATGATGATG
 
         assert total_poly_filtered <= total_poly_no_filter
 
-
     def test_mk_test_singleton_exclusion(self, tmp_path: Path) -> None:
-            """min_frequency=1/n must exclude singletons.
+        """min_frequency=1/n must exclude singletons.
 
-            Setting min_frequency to exactly 1/n can fail to
-            exclude singletons due to floating point. For n=4, derived_freq
-            computes to exactly 0.25 and 1/n = 0.25, so 0.25 < 0.25 is False
-            and the singleton passes through. 
-            """
-            n = 4
-            # 4 sequences: 3 ancestral (ATG), 1 derived (CTG) at codon 0 -> derived freq = 1/4
-            ingroup_fa = tmp_path / "ingroup.fa"
-            ingroup_fa.write_text(
-                """>s1
+        Setting min_frequency to exactly 1/n can fail to
+        exclude singletons due to floating point. For n=4, derived_freq
+        computes to exactly 0.25 and 1/n = 0.25, so 0.25 < 0.25 is False
+        and the singleton passes through.
+        """
+        n = 4
+        # 4 sequences: 3 ancestral (ATG), 1 derived (CTG) at codon 0 -> derived freq = 1/4
+        ingroup_fa = tmp_path / "ingroup.fa"
+        ingroup_fa.write_text(
+            """>s1
     ATGATGATG
     >s2
     ATGATGATG
@@ -351,16 +350,16 @@ ATGATGATG
     >s4
     CTGATGATG
     """
-            )
-            outgroup_fa = tmp_path / "outgroup.fa"
-            outgroup_fa.write_text(
-                """>o1
+        )
+        outgroup_fa = tmp_path / "outgroup.fa"
+        outgroup_fa.write_text(
+            """>o1
     ATGATGATG
     """
-            )
+        )
 
-            min_freq = 1.0 / n  # 0.25
-            result = mk_test(ingroup_fa, outgroup_fa, min_frequency=min_freq)
-            total = result.pn + result.ps
+        min_freq = 1.0 / n  # 0.25
+        result = mk_test(ingroup_fa, outgroup_fa, min_frequency=min_freq)
+        total = result.pn + result.ps
 
-            assert total == 0, f"min_frequency=1/n ({min_freq}) must exclude singletons, got {total}"
+        assert total == 0, f"min_frequency=1/n ({min_freq}) must exclude singletons, got {total}"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -19,7 +19,10 @@ class TestVolcanoPlot:
         results = [
             ("gene1", MKResult(dn=10, ds=20, pn=5, ps=10, p_value=0.5, ni=1.0, alpha=0.0, dos=0.0)),
             ("gene2", MKResult(dn=15, ds=10, pn=3, ps=8, p_value=0.01, ni=0.5, alpha=0.5, dos=0.3)),
-            ("gene3", MKResult(dn=8, ds=25, pn=6, ps=12, p_value=0.001, ni=1.5, alpha=-0.5, dos=-0.1)),
+            (
+                "gene3",
+                MKResult(dn=8, ds=25, pn=6, ps=12, p_value=0.001, ni=1.5, alpha=-0.5, dos=-0.1),
+            ),
         ]
 
         with TemporaryDirectory() as tmpdir:
@@ -82,7 +85,10 @@ class TestVolcanoPlot:
         results = [
             ("gene1", MKResult(dn=10, ds=20, pn=5, ps=10, p_value=0.5, ni=1.0, alpha=0.0, dos=0.0)),
             ("gene2", MKResult(dn=15, ds=10, pn=0, ps=8, p_value=1.0, ni=0.0, alpha=1.0, dos=0.6)),
-            ("gene3", MKResult(dn=8, ds=25, pn=6, ps=0, p_value=1.0, ni=None, alpha=None, dos=-0.76)),
+            (
+                "gene3",
+                MKResult(dn=8, ds=25, pn=6, ps=0, p_value=1.0, ni=None, alpha=None, dos=-0.76),
+            ),
         ]
 
         with TemporaryDirectory() as tmpdir:
@@ -93,8 +99,14 @@ class TestVolcanoPlot:
     def test_volcano_plot_no_valid_data(self) -> None:
         """Test that ValueError is raised when no valid data."""
         results = [
-            ("gene1", MKResult(dn=10, ds=20, pn=0, ps=10, p_value=1.0, ni=0.0, alpha=1.0, dos=0.33)),
-            ("gene2", MKResult(dn=15, ds=10, pn=0, ps=8, p_value=1.0, ni=None, alpha=None, dos=0.6)),
+            (
+                "gene1",
+                MKResult(dn=10, ds=20, pn=0, ps=10, p_value=1.0, ni=0.0, alpha=1.0, dos=0.33),
+            ),
+            (
+                "gene2",
+                MKResult(dn=15, ds=10, pn=0, ps=8, p_value=1.0, ni=None, alpha=None, dos=0.6),
+            ),
         ]
 
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds an opt-in `--sfs-mode {at,above}` flag (default `at`, backward-compatible) to the asymptotic MK test on the `test`, `batch`, and `vcf` commands. Under `above` mode, `P_n(x)` and `P_s(x)` become inclusive right-tail cumulative counts (sites with derived frequency `>= bin_edge`), per Uricchio et al. 2019 — the same form used by [MKtest.jl's `cumulative_sfs`](https://github.com/jmurga/MKtest.jl/blob/main/src/polymorphism.jl). Both modes share the asymptote at x = 1; cumulative is more sample-size-stable.
- Threads `sfs_mode` through `aggregate_polymorphism_data`, `asymptotic_mk_test_aggregated`, `asymptotic_mk_test`, the bootstrap CI rebinning step, `BatchTask`/`VcfBatchTask` for worker pickling, `AsymptoticMKResult`, the asymptotic plot's y-axis label (`α(x)` vs `α(>x)`), and the TSV/JSON/pretty output emitters.
- Documents the two SFS forms in `docs/asymptotic.rst` (new section, math, citation) and adds a one-paragraph mention plus bash example to `docs/tutorial.rst`.

Closes #8.

Backward compatibility: numeric output of `mkado test/batch/vcf -a` (no `--sfs-mode` flag) is byte-identical to `main`; the only schema change is an added `sfs_mode` column in TSV/JSON output.

The third commit (`chore:`) is a separate housekeeping pass — ruff format + drop unused `pytest`/`MKResult` imports across files untouched by this feature. Pure whitespace/import changes; no functional impact.

## Test plan

- [x] 7 new unit tests in ``tests/test_asymptotic.py::TestSfsMode`` (default-mode equivalence, cumulative semantics, invalid-mode rejection, asymptote convergence on a 30-gene fixture, mode is recorded on the result, single-gene path threading, bootstrap CI respects the mode)
- [x] 5 new CLI tests in ``tests/test_cli.py::TestSfsModeOption`` (invalid value rejected on ``test``/``batch``, default ``at`` appears in TSV, ``above`` appears in TSV, ``test`` end-to-end with ``--sfs-mode above``)
- [x] Full test suite: ``uv run pytest`` — 301 passed, 0 regressions (incl. slow bootstrap-coverage test)
- [x] Lint/format clean: ``uv run ruff check src/ tests/`` and ``uv run ruff format --check src/ tests/``
- [x] CLI smoke test on ``tests/data/kreitmanAdh.fa`` / ``mauritianaAdh.fa`` with ``--sfs-mode at`` and ``--sfs-mode above``: both produce sensible JSON, both include ``"sfs_mode"`` field
- [x] Byte-equal numeric output check: ``mkado test ... -a --sfs-mode at`` vs ``main`` — every numeric value (Dn, Ds, alpha_asymptotic, CI bounds, Ln, Ls, omega, omega_a, omega_na) is identical; only the new ``sfs_mode`` column was added to the TSV header
- [x] Docs build locally (``make -C docs html``) and the new section renders