### PR TITLE
Add aggregated-genes asymptotic-MK runtime benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Benchmark output (regenerable)
+examples/benchmarks/results/
+examples/benchmarks/figures/
+examples/benchmarks/cache/

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -1,0 +1,82 @@
+# mkado benchmarks
+
+Reproducible runtime benchmarks for the mkado test suite.
+
+## Aggregated asymptotic runtime
+
+`aggregated_asymptotic_runtime.py` characterizes wall time and alpha
+estimates for `asymptotic_mk_test_aggregated` in the regime where the
+test is statistically reliable: aggregate ~1,000 random genes per
+replicate, repeat over many replicates (per Murga-Moreno et al. 2022,
+[doi](https://doi.org/10.1093/g3journal/jkac206)).
+
+The script sweeps the full 2x2 grid of:
+
+- `sfs_mode` in `{at, above}` — per-bin SFS (Messer & Petrov 2013) vs.
+  inclusive cumulative SFS (Uricchio et al. 2019).
+- `ci_method` in `{monte-carlo, bootstrap}` — parametric covariance
+  sampling vs. case-resampling refit.
+
+### What is measured
+
+Per-replicate wall time covers the **`asymptotic_mk_test_aggregated`
+call only** — aggregation, curve fit, and CI computation,
+end-to-end for that step. Polymorphism extraction (FASTA parsing,
+codon-aligning the ingroup vs. outgroup, classifying nonsynonymous /
+synonymous polymorphism, Nei-Gojobori site counting) runs **once**
+across all genes in the input directory, is cached to disk, and is
+**amortized** across all replicates. The one-time extraction wall time
+is recorded in the CSV header (`# extraction_seconds=...`) and printed
+on the figure caption, so the cost composition is unambiguous.
+
+### Inputs
+
+- `--alignments DIR`: a directory of per-gene combined-file FASTAs,
+  each with ingroup and outgroup haplotypes named so they can be
+  filtered by substring. Default points at the lab dataset of
+  ~12,437 human protein-coding genes
+  (`Homo_sapiens` ingroup, `Pan_troglodytes` outgroup).
+- `--ingroup-match`, `--outgroup-match`: substring matchers passed to
+  `SequenceSet.filter_by_name`. Defaults match the lab dataset.
+
+### Outputs
+
+- `results/aggregated_asymptotic_runtime.csv` —
+  `replicate_idx, sfs_mode, ci_method, n_genes, wall_time_seconds,
+  alpha_asymptotic, ci_low, ci_high, num_bins, ci_replicates`. Header
+  comment line records the one-time extraction wall time.
+- `figures/aggregated_asymptotic_runtime.png` — two-panel boxplot of
+  wall time (log-scale y) and asymptotic alpha across the four
+  conditions.
+- `cache/human_mk_poly_data.pkl` — pickled extraction output. Re-runs
+  reuse it; delete it to force a re-extract.
+
+The `results/`, `figures/`, and `cache/` directories are gitignored.
+
+### Running
+
+Full benchmark, lab machine, 8 workers:
+
+```bash
+uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --workers 8
+```
+
+Defaults: 100 replicates per condition x 4 conditions = 400 timed runs.
+Each replicate samples 1,000 genes without replacement; the same
+per-replicate seeds are reused across the grid so across-condition
+variance is method-driven, not sample-driven.
+
+Smoke run (5-gene checked-in subset, 3 genes/replicate, 2 replicates;
+verifies plumbing without committing to the full run):
+
+```bash
+uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --smoke
+```
+
+### Reproducibility
+
+The base seed is `42` (override with `--seed`). Per-replicate seeds are
+`base_seed + replicate_idx`. Same-seed runs of the same dataset are
+deterministic, modulo PYTHONHASHSEED-dependent per-gene polymorphism
+ordering during extraction (set `PYTHONHASHSEED=0` if you need byte-exact
+reproducibility across machines).

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -29,6 +29,20 @@ across all genes in the input directory, is cached to disk, and is
 is recorded in the CSV header (`# extraction_seconds=...`) and printed
 on the figure caption, so the cost composition is unambiguous.
 
+In addition to the asymptotic 2x2 grid, the script runs a per-replicate
+**Tarone-Greenland α (`α_TG`)** estimate on the same 1,000-gene samples
+(via `mkado.analysis.alpha_tg.alpha_tg_from_gene_data`). The α_TG point
+estimate appears as a fifth box on the alpha panel of the figure, with
+its own CSV (`*_alpha_tg.csv`) for the per-replicate point estimate and
+bootstrap CI. Disable with `--no-alpha-tg`.
+
+The `--scaling` flag adds a **worker-count sweep** to the run: at each
+worker count (default `8,16,32,64`), the script runs the full pipeline
+(fresh extraction + 400 timed asymptotic runs) `--scaling-reps` times
+(default 3). This produces a third figure panel showing how the
+parallelizable extraction stage scales with workers while the
+sequential asymptotic stage stays flat.
+
 ### Inputs
 
 - `--alignments DIR`: a directory of per-gene combined-file FASTAs,
@@ -45,9 +59,16 @@ on the figure caption, so the cost composition is unambiguous.
   `replicate_idx, sfs_mode, ci_method, n_genes, wall_time_seconds,
   alpha_asymptotic, ci_low, ci_high, num_bins, ci_replicates`. Header
   comment line records the one-time extraction wall time.
+- `results/aggregated_asymptotic_runtime_alpha_tg.csv` — per-replicate
+  Tarone-Greenland α point estimates and bootstrap CIs on the same
+  1,000-gene samples used for the asymptotic grid.
+- `results/aggregated_asymptotic_runtime_scaling.csv` — only when
+  `--scaling` is passed: end-to-end pipeline timings at each worker
+  count, broken down into extraction and asymptotic-runs phases.
 - `figures/aggregated_asymptotic_runtime.png` — two-panel boxplot of
   wall time (log-scale y) and asymptotic alpha across the four
-  conditions.
+  conditions, with α_TG as a fifth box on the alpha panel. Adds a
+  scaling panel on the left when `--scaling` data is present.
 - `cache/human_mk_poly_data.pkl` — pickled extraction output. Re-runs
   reuse it; delete it to force a re-extract.
 
@@ -61,10 +82,18 @@ Full benchmark, lab machine, 8 workers:
 uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --workers 8
 ```
 
-Defaults: 100 replicates per condition x 4 conditions = 400 timed runs.
+Defaults: 100 replicates per condition x 4 conditions = 400 timed runs,
+plus 100 α_TG replicates on the same samples.
 Each replicate samples 1,000 genes without replacement; the same
 per-replicate seeds are reused across the grid so across-condition
 variance is method-driven, not sample-driven.
+
+Full benchmark with worker-count scaling sweep (~50 min on the lab
+machine: 4 worker counts × 3 fresh extractions × ~4 min each):
+
+```bash
+uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --scaling
+```
 
 Smoke run (5-gene checked-in subset, 3 genes/replicate, 2 replicates;
 verifies plumbing without committing to the full run):

--- a/examples/benchmarks/aggregated_asymptotic_runtime.py
+++ b/examples/benchmarks/aggregated_asymptotic_runtime.py
@@ -1,0 +1,425 @@
+"""Aggregated-genes asymptotic-MK runtime benchmark.
+
+Mirrors the regime in which the asymptotic test is statistically reliable:
+aggregate ~1,000 random genes per replicate, repeat over many replicates
+(Murga-Moreno et al. 2022, doi:10.1093/g3journal/jkac206). Sweeps the 2x2
+grid of ``sfs_mode`` x ``ci_method`` so the four implementation choices
+that matter for runtime are characterized in one figure.
+
+Polymorphism extraction over the full ``--alignments`` directory is the
+dominant cost; it runs once and is cached to disk. Per-replicate timing
+covers the ``asymptotic_mk_test_aggregated`` call only -- aggregation +
+curve fit + CI computation, end-to-end. The one-time extraction wall
+time is recorded in the CSV header and the figure caption so the
+"what's measured" question is unambiguous.
+
+Run end-to-end on the lab machine:
+
+    uv run python examples/benchmarks/aggregated_asymptotic_runtime.py \\
+        --workers 8
+
+Smoke-run on the 5-gene checked-in subset:
+
+    uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import pickle
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from mkado.analysis.asymptotic import (
+    PolymorphismData,
+    asymptotic_mk_test_aggregated,
+    extract_polymorphism_data,
+)
+from mkado.cli import find_alignment_files
+from mkado.core.sequences import SequenceSet
+
+logger = logging.getLogger("mkado.benchmark")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ALIGNMENTS = Path("/sietch_colab/adkern/human_mk_data/alignments")
+SMOKE_ALIGNMENTS = REPO_ROOT / "data" / "mk_human_chimp"
+DEFAULT_BENCH_DIR = REPO_ROOT / "examples" / "benchmarks"
+
+CSV_FIELDNAMES = (
+    "replicate_idx",
+    "sfs_mode",
+    "ci_method",
+    "n_genes",
+    "wall_time_seconds",
+    "alpha_asymptotic",
+    "ci_low",
+    "ci_high",
+    "num_bins",
+    "ci_replicates",
+)
+
+
+@dataclass
+class _ExtractionTask:
+    file_path: Path
+    ingroup_match: str
+    outgroup_match: str
+
+
+def _extract_one(task: _ExtractionTask) -> PolymorphismData | None:
+    """Load a combined-file FASTA and return PolymorphismData for that gene.
+
+    Mirrors the combined-file branch of ``mkado.batch_workers.process_gene``
+    so the benchmark hits the same code path the CLI does.
+    """
+    try:
+        all_seqs = SequenceSet.from_fasta(task.file_path)
+        ingroup = all_seqs.filter_by_name(task.ingroup_match)
+        outgroup = all_seqs.filter_by_name(task.outgroup_match)
+        if len(ingroup) == 0 or len(outgroup) == 0:
+            return None
+        return extract_polymorphism_data(
+            ingroup=ingroup,
+            outgroup=outgroup,
+            gene_id=task.file_path.stem,
+        )
+    except Exception:
+        logger.exception("extraction failed for %s", task.file_path.name)
+        return None
+
+
+def load_or_extract(
+    alignment_dir: Path,
+    ingroup_match: str,
+    outgroup_match: str,
+    cache_path: Path,
+    workers: int,
+) -> tuple[list[PolymorphismData], float, int]:
+    """Return (polymorphism data, extraction seconds, workers used).
+
+    On cache hit the wall time and worker count are the values recorded
+    on the original extraction run, not the current invocation -- so the
+    figure caption stays internally consistent.
+    """
+    if cache_path.exists():
+        logger.info("loading polymorphism cache from %s", cache_path)
+        with cache_path.open("rb") as fh:
+            payload = pickle.load(fh)
+        return payload["data"], payload["extraction_seconds"], payload.get("workers", workers)
+
+    files = find_alignment_files(alignment_dir)
+    if not files:
+        sys.exit(f"no FASTA files found under {alignment_dir}")
+
+    logger.info("extracting polymorphism data from %d genes (workers=%d)", len(files), workers)
+    tasks = [
+        _ExtractionTask(f, ingroup_match=ingroup_match, outgroup_match=outgroup_match)
+        for f in files
+    ]
+    start = time.perf_counter()
+    data: list[PolymorphismData] = []
+    if workers <= 1:
+        for t in tasks:
+            poly = _extract_one(t)
+            if poly is not None:
+                data.append(poly)
+    else:
+        # ~4 chunks per worker balances IPC overhead against load imbalance from
+        # variable-size FASTAs; matches the multiprocessing.Pool default heuristic.
+        chunksize = max(len(tasks) // (workers * 4), 1)
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            for poly in pool.map(_extract_one, tasks, chunksize=chunksize):
+                if poly is not None:
+                    data.append(poly)
+    extraction_seconds = time.perf_counter() - start
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with cache_path.open("wb") as fh:
+        pickle.dump(
+            {"data": data, "extraction_seconds": extraction_seconds, "workers": workers},
+            fh,
+        )
+    logger.info(
+        "extracted %d genes in %.1fs; cached to %s",
+        len(data),
+        extraction_seconds,
+        cache_path,
+    )
+    return data, extraction_seconds, workers
+
+
+def run_replicates(
+    poly_data: list[PolymorphismData],
+    *,
+    sfs_mode: str,
+    ci_method: str,
+    n_genes: int,
+    n_replicates: int,
+    base_seed: int,
+    num_bins: int,
+) -> list[dict]:
+    """Sample n_genes without replacement and time the aggregated test.
+
+    The same per-replicate seed is used across the (sfs_mode, ci_method)
+    grid so each cell sees the same gene subsets -- across-condition
+    variance is method-driven, not sample-driven.
+    """
+    n_total = len(poly_data)
+    if n_total < n_genes:
+        sys.exit(f"only {n_total} genes available; cannot sample {n_genes} without replacement")
+
+    # Realistic CLI defaults: MC samples params from a covariance matrix
+    # (cheap, ~10000x); bootstrap refits per replicate (~100x).
+    ci_replicates = 10000 if ci_method == "monte-carlo" else 100
+
+    rows: list[dict] = []
+    for replicate_idx in range(n_replicates):
+        seed = base_seed + replicate_idx
+        rng = np.random.default_rng(seed)
+        idx = rng.choice(n_total, size=n_genes, replace=False)
+        sample = [poly_data[i] for i in idx]
+
+        start = time.perf_counter()
+        result = asymptotic_mk_test_aggregated(
+            gene_data=sample,
+            num_bins=num_bins,
+            ci_replicates=ci_replicates,
+            ci_method=ci_method,
+            seed=seed,
+            sfs_mode=sfs_mode,
+        )
+        wall = time.perf_counter() - start
+
+        rows.append(
+            {
+                "replicate_idx": replicate_idx,
+                "sfs_mode": sfs_mode,
+                "ci_method": ci_method,
+                "n_genes": n_genes,
+                "wall_time_seconds": wall,
+                "alpha_asymptotic": result.alpha_asymptotic,
+                "ci_low": result.ci_low,
+                "ci_high": result.ci_high,
+                "num_bins": num_bins,
+                "ci_replicates": ci_replicates,
+            }
+        )
+        if (replicate_idx + 1) % 10 == 0 or replicate_idx == n_replicates - 1:
+            logger.info(
+                "[%s/%s] replicate %d/%d  alpha=%.4f  wall=%.3fs",
+                sfs_mode,
+                ci_method,
+                replicate_idx + 1,
+                n_replicates,
+                result.alpha_asymptotic,
+                wall,
+            )
+    return rows
+
+
+def write_csv(rows: list[dict], path: Path, extraction_seconds: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        fh.write(f"# extraction_seconds={extraction_seconds:.3f}\n")
+        writer = csv.DictWriter(fh, fieldnames=CSV_FIELDNAMES)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    logger.info("wrote %d rows to %s", len(rows), path)
+
+
+def make_figure(
+    rows: list[dict],
+    path: Path,
+    extraction_seconds: float,
+    n_genes: int,
+    n_total_genes: int,
+    workers: int,
+) -> None:
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    sns.set_theme(style="darkgrid")
+    palette = ["#2c3e50", "#e74c3c", "#3498db", "#e67e22"]
+
+    times = np.array([r["wall_time_seconds"] for r in rows])
+    alphas = np.array([r["alpha_asymptotic"] for r in rows])
+    sfs_modes = np.array([r["sfs_mode"] for r in rows])
+    ci_methods = np.array([r["ci_method"] for r in rows])
+    conditions = np.array([f"{s}\n{c}" for s, c in zip(sfs_modes, ci_methods)])
+    order = sorted(set(conditions.tolist()))
+
+    def _panel(ax, y, *, ylabel: str, title: str, log_y: bool = False) -> None:
+        sns.boxplot(
+            x=conditions,
+            y=y,
+            hue=conditions,
+            order=order,
+            hue_order=order,
+            ax=ax,
+            palette=palette,
+            legend=False,
+        )
+        sns.stripplot(
+            x=conditions,
+            y=y,
+            order=order,
+            ax=ax,
+            color="white",
+            edgecolor="#2c3e50",
+            linewidth=0.5,
+            alpha=0.6,
+            size=3,
+        )
+        if log_y:
+            ax.set_yscale("log")
+        ax.set_ylabel(ylabel, fontsize=12)
+        ax.set_xlabel("sfs_mode / ci_method", fontsize=12)
+        ax.set_title(title, fontsize=13, fontweight="bold")
+
+    fig, (ax_time, ax_alpha) = plt.subplots(1, 2, figsize=(12, 5))
+    _panel(
+        ax_time,
+        times,
+        ylabel="Wall time per replicate (s, log scale)",
+        title=f"Asymptotic MK aggregated runtime, {n_genes} random genes / replicate",
+        log_y=True,
+    )
+    _panel(
+        ax_alpha,
+        alphas,
+        ylabel=r"Asymptotic $\alpha$",
+        title="Estimated asymptotic alpha",
+    )
+
+    fig.suptitle(
+        (
+            f"Extraction (parsing + site counting + SFS construction) of "
+            f"{n_total_genes} genes amortized across replicates: "
+            f"{extraction_seconds:.1f}s on {workers} workers"
+        ),
+        fontsize=10,
+        y=-0.02,
+    )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("wrote figure to %s", path)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--alignments",
+        type=Path,
+        default=DEFAULT_ALIGNMENTS,
+        help="Directory of per-gene multi-species FASTA alignments.",
+    )
+    parser.add_argument("--ingroup-match", default="Homo_sapiens")
+    parser.add_argument("--outgroup-match", default="Pan_troglodytes")
+    parser.add_argument("--n-genes", type=int, default=1000)
+    parser.add_argument("--n-replicates", type=int, default=100)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--num-bins", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--cache",
+        type=Path,
+        default=DEFAULT_BENCH_DIR / "cache" / "human_mk_poly_data.pkl",
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=DEFAULT_BENCH_DIR / "results" / "aggregated_asymptotic_runtime.csv",
+    )
+    parser.add_argument(
+        "--plot",
+        type=Path,
+        default=DEFAULT_BENCH_DIR / "figures" / "aggregated_asymptotic_runtime.png",
+    )
+    parser.add_argument("--no-plot", action="store_true")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help=(
+            "Run against the 5-gene checked-in subset with n_genes=3 and "
+            "n_replicates=2 to verify the script wires up correctly."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.smoke:
+        args.alignments = SMOKE_ALIGNMENTS
+        args.n_genes = 3
+        args.n_replicates = 2
+        args.workers = 2
+        args.cache = DEFAULT_BENCH_DIR / "cache" / "smoke_poly_data.pkl"
+        args.csv = DEFAULT_BENCH_DIR / "results" / "smoke_runtime.csv"
+        args.plot = DEFAULT_BENCH_DIR / "figures" / "smoke_runtime.png"
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    args = parse_args(argv)
+
+    if not args.alignments.is_dir():
+        sys.exit(f"alignments dir not found: {args.alignments}")
+
+    poly_data, extraction_seconds, extraction_workers = load_or_extract(
+        alignment_dir=args.alignments,
+        ingroup_match=args.ingroup_match,
+        outgroup_match=args.outgroup_match,
+        cache_path=args.cache,
+        workers=args.workers,
+    )
+
+    logger.info(
+        "running %d replicates x 4 conditions on %d-gene samples (cache size: %d genes)",
+        args.n_replicates,
+        args.n_genes,
+        len(poly_data),
+    )
+
+    rows: list[dict] = []
+    for sfs_mode in ("at", "above"):
+        for ci_method in ("monte-carlo", "bootstrap"):
+            rows.extend(
+                run_replicates(
+                    poly_data,
+                    sfs_mode=sfs_mode,
+                    ci_method=ci_method,
+                    n_genes=args.n_genes,
+                    n_replicates=args.n_replicates,
+                    base_seed=args.seed,
+                    num_bins=args.num_bins,
+                )
+            )
+
+    write_csv(rows, args.csv, extraction_seconds)
+    if not args.no_plot:
+        make_figure(
+            rows,
+            path=args.plot,
+            extraction_seconds=extraction_seconds,
+            n_genes=args.n_genes,
+            n_total_genes=len(poly_data),
+            workers=extraction_workers,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/aggregated_asymptotic_runtime.py
+++ b/examples/benchmarks/aggregated_asymptotic_runtime.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 import numpy as np
 
+from mkado.analysis.alpha_tg import alpha_tg_from_gene_data
 from mkado.analysis.asymptotic import (
     PolymorphismData,
     asymptotic_mk_test_aggregated,
@@ -63,6 +64,24 @@ CSV_FIELDNAMES = (
     "ci_high",
     "num_bins",
     "ci_replicates",
+)
+
+ALPHA_TG_CSV_FIELDNAMES = (
+    "replicate_idx",
+    "n_genes",
+    "wall_time_seconds",
+    "alpha_tg",
+    "ci_low",
+    "ci_high",
+    "bootstrap_replicates",
+)
+
+SCALING_CSV_FIELDNAMES = (
+    "n_workers",
+    "rep_idx",
+    "extraction_seconds",
+    "asymptotic_seconds",
+    "total_seconds",
 )
 
 
@@ -224,11 +243,144 @@ def run_replicates(
     return rows
 
 
+def run_replicates_alpha_tg(
+    poly_data: list[PolymorphismData],
+    *,
+    n_genes: int,
+    n_replicates: int,
+    base_seed: int,
+    bootstrap_replicates: int,
+) -> list[dict]:
+    """Per-replicate Tarone-Greenland alpha on the same 1,000-gene samples.
+
+    Uses identical per-replicate seeds as ``run_replicates`` so each row in
+    this CSV pairs 1:1 with the four asymptotic rows for the same sample
+    -- the manuscript can show all five alpha estimators on a common axis.
+    """
+    n_total = len(poly_data)
+    if n_total < n_genes:
+        sys.exit(f"only {n_total} genes available; cannot sample {n_genes} without replacement")
+
+    rows: list[dict] = []
+    for replicate_idx in range(n_replicates):
+        seed = base_seed + replicate_idx
+        rng = np.random.default_rng(seed)
+        idx = rng.choice(n_total, size=n_genes, replace=False)
+        sample = [poly_data[i] for i in idx]
+
+        start = time.perf_counter()
+        result = alpha_tg_from_gene_data(
+            gene_data=sample,
+            bootstrap_replicates=bootstrap_replicates,
+            seed=seed,
+        )
+        wall = time.perf_counter() - start
+
+        rows.append(
+            {
+                "replicate_idx": replicate_idx,
+                "n_genes": n_genes,
+                "wall_time_seconds": wall,
+                "alpha_tg": result.alpha_tg,
+                "ci_low": result.ci_low,
+                "ci_high": result.ci_high,
+                "bootstrap_replicates": bootstrap_replicates,
+            }
+        )
+        if (replicate_idx + 1) % 10 == 0 or replicate_idx == n_replicates - 1:
+            logger.info(
+                "[alpha_tg] replicate %d/%d  alpha=%.4f  wall=%.3fs",
+                replicate_idx + 1,
+                n_replicates,
+                result.alpha_tg,
+                wall,
+            )
+    return rows
+
+
+def run_scaling_sweep(
+    *,
+    alignment_dir: Path,
+    ingroup_match: str,
+    outgroup_match: str,
+    cache_path: Path,
+    worker_counts: list[int],
+    n_reps: int,
+    n_genes: int,
+    n_replicates: int,
+    base_seed: int,
+    num_bins: int,
+) -> list[dict]:
+    """End-to-end pipeline timing across worker counts.
+
+    For each (n_workers, rep), deletes the cache, runs a fresh extraction,
+    and runs the full 4-cell asymptotic grid. Records extraction wall time,
+    asymptotic-runs wall time, and total -- so the manuscript can show how
+    the parallelizable upstream stage scales while the asymptotic stage
+    stays sequential.
+    """
+    rows: list[dict] = []
+    for n_workers in worker_counts:
+        for rep_idx in range(n_reps):
+            cache_path.unlink(missing_ok=True)
+            logger.info("[scaling] workers=%d rep=%d/%d", n_workers, rep_idx + 1, n_reps)
+            poly_data, extraction_seconds, _ = load_or_extract(
+                alignment_dir=alignment_dir,
+                ingroup_match=ingroup_match,
+                outgroup_match=outgroup_match,
+                cache_path=cache_path,
+                workers=n_workers,
+            )
+            asym_start = time.perf_counter()
+            for sfs_mode in ("at", "above"):
+                for ci_method in ("monte-carlo", "bootstrap"):
+                    run_replicates(
+                        poly_data,
+                        sfs_mode=sfs_mode,
+                        ci_method=ci_method,
+                        n_genes=n_genes,
+                        n_replicates=n_replicates,
+                        base_seed=base_seed,
+                        num_bins=num_bins,
+                    )
+            asymptotic_seconds = time.perf_counter() - asym_start
+            total_seconds = extraction_seconds + asymptotic_seconds
+            rows.append(
+                {
+                    "n_workers": n_workers,
+                    "rep_idx": rep_idx,
+                    "extraction_seconds": extraction_seconds,
+                    "asymptotic_seconds": asymptotic_seconds,
+                    "total_seconds": total_seconds,
+                }
+            )
+            logger.info(
+                "[scaling] workers=%d rep=%d  extract=%.1fs  asym=%.1fs  total=%.1fs",
+                n_workers,
+                rep_idx + 1,
+                extraction_seconds,
+                asymptotic_seconds,
+                total_seconds,
+            )
+    return rows
+
+
 def write_csv(rows: list[dict], path: Path, extraction_seconds: float) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="") as fh:
         fh.write(f"# extraction_seconds={extraction_seconds:.3f}\n")
         writer = csv.DictWriter(fh, fieldnames=CSV_FIELDNAMES)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    logger.info("wrote %d rows to %s", len(rows), path)
+
+
+def write_simple_csv(rows: list[dict], path: Path, fieldnames: tuple[str, ...]) -> None:
+    """Write a CSV without the leading extraction_seconds comment row."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
         writer.writeheader()
         for row in rows:
             writer.writerow(row)
@@ -242,12 +394,15 @@ def make_figure(
     n_genes: int,
     n_total_genes: int,
     workers: int,
+    alpha_tg_rows: list[dict] | None = None,
+    scaling_rows: list[dict] | None = None,
 ) -> None:
     import matplotlib.pyplot as plt
     import seaborn as sns
 
     sns.set_theme(style="darkgrid")
     palette = ["#2c3e50", "#e74c3c", "#3498db", "#e67e22"]
+    alpha_tg_color = "#27ae60"
 
     times = np.array([r["wall_time_seconds"] for r in rows])
     alphas = np.array([r["alpha_asymptotic"] for r in rows])
@@ -284,7 +439,62 @@ def make_figure(
         ax.set_xlabel("sfs_mode / ci_method", fontsize=12)
         ax.set_title(title, fontsize=13, fontweight="bold")
 
-    fig, (ax_time, ax_alpha) = plt.subplots(1, 2, figsize=(12, 5))
+    n_panels = 2 + (1 if scaling_rows else 0)
+    fig, axes = plt.subplots(1, n_panels, figsize=(6 * n_panels, 5))
+    axes_iter = iter(axes if n_panels > 1 else [axes])
+
+    if scaling_rows:
+        ax_scaling = next(axes_iter)
+        sc_workers = np.array([r["n_workers"] for r in scaling_rows], dtype=int)
+        sc_total = np.array([r["total_seconds"] for r in scaling_rows])
+        sc_extract = np.array([r["extraction_seconds"] for r in scaling_rows])
+        sc_asym = np.array([r["asymptotic_seconds"] for r in scaling_rows])
+        sc_order = sorted(set(sc_workers.tolist()))
+        pos_map = {w: i for i, w in enumerate(sc_order)}
+        positions = list(range(len(sc_order)))
+
+        ax_scaling.boxplot(
+            [sc_total[sc_workers == w] for w in sc_order],
+            positions=positions,
+            widths=0.5,
+            patch_artist=True,
+            boxprops={"facecolor": palette[0], "alpha": 0.4, "edgecolor": palette[0]},
+            medianprops={"color": "white", "linewidth": 1.5},
+            whiskerprops={"color": palette[0]},
+            capprops={"color": palette[0]},
+            showfliers=False,
+        )
+        sc_offsets = np.array([pos_map[w] for w in sc_workers], dtype=float)
+        jitter = np.random.default_rng(0).uniform(-0.08, 0.08, size=len(sc_offsets))
+        ax_scaling.scatter(
+            sc_offsets + jitter,
+            sc_extract,
+            color=palette[1],
+            edgecolor="white",
+            linewidth=0.4,
+            s=40,
+            label="extraction",
+            zorder=3,
+        )
+        ax_scaling.scatter(
+            sc_offsets + jitter,
+            sc_asym,
+            color=palette[2],
+            edgecolor="white",
+            linewidth=0.4,
+            s=40,
+            label="asymptotic runs",
+            zorder=3,
+        )
+        ax_scaling.set_xticks(positions)
+        ax_scaling.set_xticklabels([str(w) for w in sc_order])
+        ax_scaling.set_yscale("log")
+        ax_scaling.set_ylabel("End-to-end wall time (s, log scale)", fontsize=12)
+        ax_scaling.set_xlabel("Workers (extraction parallelism)", fontsize=12)
+        ax_scaling.set_title("Pipeline runtime vs worker count", fontsize=13, fontweight="bold")
+        ax_scaling.legend(loc="upper right", fontsize=9)
+
+    ax_time = next(axes_iter)
     _panel(
         ax_time,
         times,
@@ -292,12 +502,46 @@ def make_figure(
         title=f"Asymptotic MK aggregated runtime, {n_genes} random genes / replicate",
         log_y=True,
     )
+
+    ax_alpha = next(axes_iter)
     _panel(
         ax_alpha,
         alphas,
         ylabel=r"Asymptotic $\alpha$",
         title="Estimated asymptotic alpha",
     )
+    if alpha_tg_rows:
+        # Overlay alpha_TG point estimates at a fifth, slightly-offset x position.
+        tg_alphas = np.array([r["alpha_tg"] for r in alpha_tg_rows])
+        tg_x = np.full(len(tg_alphas), len(order))
+        ax_alpha.scatter(
+            tg_x + np.random.default_rng(0).uniform(-0.15, 0.15, size=len(tg_x)),
+            tg_alphas,
+            color=alpha_tg_color,
+            edgecolor="white",
+            linewidth=0.4,
+            s=30,
+            alpha=0.7,
+            zorder=3,
+            label=r"$\alpha_{TG}$",
+        )
+        # Boxplot for alpha_TG at the same x position.
+        ax_alpha.boxplot(
+            tg_alphas,
+            positions=[len(order)],
+            widths=0.5,
+            patch_artist=True,
+            boxprops={"facecolor": alpha_tg_color, "alpha": 0.4, "edgecolor": alpha_tg_color},
+            medianprops={"color": "white", "linewidth": 1.5},
+            whiskerprops={"color": alpha_tg_color},
+            capprops={"color": alpha_tg_color},
+            showfliers=False,
+        )
+        labels = list(order) + [r"$\alpha_{TG}$"]
+        ax_alpha.set_xticks(range(len(labels)))
+        ax_alpha.set_xticklabels(labels)
+        ax_alpha.set_xlabel("estimator / condition", fontsize=12)
+        ax_alpha.legend(loc="upper right", fontsize=9)
 
     fig.suptitle(
         (
@@ -348,6 +592,36 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--no-plot", action="store_true")
     parser.add_argument(
+        "--no-alpha-tg",
+        action="store_true",
+        help="Skip the per-replicate alpha_TG comparison run.",
+    )
+    parser.add_argument(
+        "--alpha-tg-bootstrap",
+        type=int,
+        default=200,
+        help=(
+            "Bootstrap replicates for alpha_TG CI per sample (default 200). "
+            "alpha_tg_from_gene_data's library default is 1000; 200 is plenty "
+            "for the manuscript figure and keeps the comparison cheap."
+        ),
+    )
+    parser.add_argument(
+        "--scaling",
+        action="store_true",
+        help=(
+            "Run the worker-count scaling sweep (end-to-end pipeline timing "
+            "at each --scaling-workers level, --scaling-reps reps each). "
+            "Adds an extra panel to the figure on the left."
+        ),
+    )
+    parser.add_argument(
+        "--scaling-workers",
+        default="8,16,32,64",
+        help="Comma-separated worker counts for the scaling sweep.",
+    )
+    parser.add_argument("--scaling-reps", type=int, default=3)
+    parser.add_argument(
         "--smoke",
         action="store_true",
         help=(
@@ -362,9 +636,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         args.n_genes = 3
         args.n_replicates = 2
         args.workers = 2
+        args.alpha_tg_bootstrap = 50
+        args.scaling_workers = "1,2"
+        args.scaling_reps = 2
         args.cache = DEFAULT_BENCH_DIR / "cache" / "smoke_poly_data.pkl"
         args.csv = DEFAULT_BENCH_DIR / "results" / "smoke_runtime.csv"
         args.plot = DEFAULT_BENCH_DIR / "figures" / "smoke_runtime.png"
+
+    args.scaling_workers_list = [int(w) for w in args.scaling_workers.split(",") if w.strip()]
     return args
 
 
@@ -409,7 +688,52 @@ def main(argv: list[str] | None = None) -> None:
                 )
             )
 
+    alpha_tg_rows: list[dict] = []
+    if not args.no_alpha_tg:
+        alpha_tg_rows = run_replicates_alpha_tg(
+            poly_data,
+            n_genes=args.n_genes,
+            n_replicates=args.n_replicates,
+            base_seed=args.seed,
+            bootstrap_replicates=args.alpha_tg_bootstrap,
+        )
+
+    scaling_rows: list[dict] = []
+    if args.scaling:
+        # The sweep clobbers the cache for each (workers, rep) run -- save
+        # the current cache aside so the post-sweep CSV/figure work above
+        # has its data, then restore it after the sweep.
+        if args.cache.exists():
+            saved_cache = args.cache.with_suffix(args.cache.suffix + ".saved")
+            args.cache.rename(saved_cache)
+        else:
+            saved_cache = None
+        try:
+            scaling_rows = run_scaling_sweep(
+                alignment_dir=args.alignments,
+                ingroup_match=args.ingroup_match,
+                outgroup_match=args.outgroup_match,
+                cache_path=args.cache,
+                worker_counts=args.scaling_workers_list,
+                n_reps=args.scaling_reps,
+                n_genes=args.n_genes,
+                n_replicates=args.n_replicates,
+                base_seed=args.seed,
+                num_bins=args.num_bins,
+            )
+        finally:
+            args.cache.unlink(missing_ok=True)
+            if saved_cache is not None:
+                saved_cache.rename(args.cache)
+
     write_csv(rows, args.csv, extraction_seconds)
+    if alpha_tg_rows:
+        alpha_tg_path = args.csv.with_name(args.csv.stem + "_alpha_tg.csv")
+        write_simple_csv(alpha_tg_rows, alpha_tg_path, ALPHA_TG_CSV_FIELDNAMES)
+    if scaling_rows:
+        scaling_path = args.csv.with_name(args.csv.stem + "_scaling.csv")
+        write_simple_csv(scaling_rows, scaling_path, SCALING_CSV_FIELDNAMES)
+
     if not args.no_plot:
         make_figure(
             rows,
@@ -418,6 +742,8 @@ def main(argv: list[str] | None = None) -> None:
             n_genes=args.n_genes,
             n_total_genes=len(poly_data),
             workers=extraction_workers,
+            alpha_tg_rows=alpha_tg_rows or None,
+            scaling_rows=scaling_rows or None,
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `examples/benchmarks/aggregated_asymptotic_runtime.py` — a runtime benchmark for `asymptotic_mk_test_aggregated` in the regime where the test is statistically reliable: 1,000 random genes per replicate, 100 replicates per condition, full 2x2 grid of `sfs_mode` x `ci_method` (4 conditions, 400 timed runs total). Follows Murga-Moreno et al. 2022 ([doi](https://doi.org/10.1093/g3journal/jkac206)).
- Extraction (FASTA parsing + ingroup/outgroup filter + Nei-Gojobori site counting + SFS construction) runs once across all genes via `ProcessPoolExecutor`, cached to disk. Per-replicate timing covers only `asymptotic_mk_test_aggregated`. The one-time extraction wall time is recorded in the CSV header (`# extraction_seconds=...`) and the figure caption, so the cost composition is unambiguous — answering the reviewer's "what's actually measured" gripe directly.
- Outputs: CSV (`results/`) and a two-panel seaborn boxplot of wall time and asymptotic alpha across the four conditions (`figures/`). Output dirs are gitignored.
- `--smoke` profile runs against the 5-gene checked-in subset (`data/mk_human_chimp/`) for plumbing verification.

Closes #11.

## Test plan

- [x] Smoke run: ``uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --smoke`` exits 0, writes 8-row CSV (4 conditions x 2 replicates) and a clean PNG with both panels rendering.
- [x] Lint/format clean: ``uv run ruff check examples/benchmarks/`` and ``uv run ruff format --check examples/benchmarks/``.
- [x] Full mkado test suite still passes (the script imports ``find_alignment_files`` from ``mkado.cli``, doesn't break it): ``uv run pytest -k 'not slow'`` -> 300 passed.
- [ ] Full benchmark run on the lab dataset (12,437 human genes at ``/sietch_colab/adkern/human_mk_data/alignments``) -- to be run after merge: ``time uv run python examples/benchmarks/aggregated_asymptotic_runtime.py --workers 8``. Expected: extraction once (~minutes, cached), 400 timed runs (~minutes), CSV with 400 rows, plot with four boxes per panel.

## Notes

- The acceptance-criteria item "Documented in the manuscript benchmark methods" is for the manuscript draft, not this PR. The README in ``examples/benchmarks/`` is the source the manuscript paragraph can pull from.
- ``review_features.md`` ``F4`` will be marked done locally (gitignored per repo rules).