### PR TITLE
docs: address reviewer comments R2.5/R2.8/R2.9 and R1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ wheels/
 examples/benchmarks/results/
 examples/benchmarks/figures/
 examples/benchmarks/cache/
+
+# Manuscript repo (cloned locally, tracked separately)
+mkado-paper/

--- a/docs/batch-workflow.rst
+++ b/docs/batch-workflow.rst
@@ -18,6 +18,27 @@ To process all alignment files in a directory:
 
 This scans for FASTA files (``*.fa``, ``*.fasta``, ``*.fna``) and runs the MK test on each.
 
+Per-gene vs Aggregated Modes
+----------------------------
+
+Tests that estimate a single α across many genes (asymptotic MK, imputed MK, Tarone-Greenland α_TG) accept ``--aggregate`` and ``--per-gene``:
+
+- ``--aggregate`` (default for these tests): pool polymorphism and divergence counts across **all** input genes, then fit / compute α once. This is the recommended mode for the asymptotic MK test, where per-gene SFS data are too sparse to fit reliably; it also matches the regime in which asymptotic MK has been validated (see `Murga-Moreno et al. 2022`_).
+
+- ``--per-gene``: run a separate test on each gene and report one α per gene. Useful when you want gene-by-gene point estimates (with the caveat that per-gene asymptotic estimates are noisy).
+
+The standard MK test is naturally per-gene and ignores ``--aggregate``; ``mkado batch`` always reports one row per gene for the standard test, plus aggregated counts in the summary.
+
+.. code-block:: bash
+
+   # Aggregated asymptotic MK (default)
+   mkado batch alignments/ -i species1 -o species2 -a
+
+   # Per-gene asymptotic MK (one α per gene)
+   mkado batch alignments/ -i species1 -o species2 -a --per-gene
+
+.. _Murga-Moreno et al. 2022: https://doi.org/10.1093/g3journal/jkac206
+
 File Organization
 -----------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,19 +61,6 @@ After development installation:
    # Run specific test file
    uv run pytest tests/test_mk_test.py -v
 
-Linting and Formatting
-----------------------
-
-MKado uses `ruff <https://docs.astral.sh/ruff/>`_ for linting and formatting:
-
-.. code-block:: bash
-
-   # Check for lint errors
-   uv run ruff check src/
-
-   # Format code
-   uv run ruff format src/
-
 Verifying Installation
 ----------------------
 
@@ -84,3 +71,27 @@ After installation, verify it works:
    mkado --help
 
 You should see the help output listing available commands.
+
+Shell Completion
+----------------
+
+MKado ships with `Typer <https://typer.tiangolo.com>`_'s built-in shell
+completion. Two options on the umbrella ``mkado`` command let you
+configure it:
+
+.. code-block:: bash
+
+   # Install completion for your current shell (bash, zsh, fish, powershell)
+   mkado --install-completion
+
+   # Print the completion script without installing it
+   mkado --show-completion
+
+Restart your shell after installing.
+
+.. note::
+
+   Completion may be slow on some systems because each completion
+   request loads the full ``mkado`` Python entry point. If you find
+   the lag distracting, simply leave completion uninstalled---it does
+   not affect any other behaviour.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -540,6 +540,68 @@ If your starting point is a variant calling pipeline (e.g., GATK, bcftools) rath
 
 See :doc:`vcf-input` for the full guide, including data preparation, gene filtering, plotting, and all available options.
 
+Working with Ortholog Alignments (OrthoMaM-style projection)
+------------------------------------------------------------
+
+A common scenario when working with non-model organisms is that one
+has codon-aligned ortholog sets from a database such as `OrthoMaM
+<https://orthomam.mbb.cnrs.fr>`_ (mammals), Ensembl Compara, or a
+custom alignment, plus a separate population-genetic VCF for the
+ingroup species. To use these together with MKado, the polymorphism
+data must be projected onto the alignment columns. The procedure
+below mirrors the one we used to assemble the 12,437-gene human
+benchmark dataset and is general enough to apply to any codon-level
+ortholog alignment plus a coordinate-resolved VCF.
+
+For each gene, do the following:
+
+1. **Reconstruct the canonical CDS** for the ingroup species from
+   the reference genome (FASTA) and exon set (GTF/GFF3), so you
+   have a position-by-position mapping from CDS index to genomic
+   coordinate. For minus-strand genes, reverse-complement as you
+   build the CDS.
+
+2. **Match the alignment to the CDS.** Strip gaps from the ingroup
+   row of the ortholog alignment, then look for it as a substring
+   of the reconstructed canonical CDS. The position of the match
+   gives you the alignment-column to CDS-position
+   correspondence. Genes whose alignments do not match the
+   reference CDS exactly (commonly the result of independent
+   curation between alignment database and reference) should be
+   skipped.
+
+3. **Extract overlapping variants from the VCF** using the genomic
+   coordinates from step 1 for the alignment-retained CDS
+   positions. Verify that the VCF reference allele matches the
+   genomic reference; for minus-strand genes, complement the VCF
+   alleles to match the CDS orientation.
+
+4. **Build per-haplotype sequences.** From the phased VCF
+   genotypes, write out one CDS sequence per haplotype with
+   variants substituted in. This step yields *2N* (or *N*, for
+   haploid samples) haplotype CDS sequences over the alignment-
+   retained positions.
+
+5. **Re-gap to the alignment.** Insert the gap structure of the
+   ortholog alignment into each haplotype sequence, so that all
+   haplotypes are codon-aligned to one another and to the outgroup
+   sequences from the alignment. Outgroup sequences are taken
+   directly from the alignment.
+
+The output of this pipeline is a per-gene multi-species FASTA file
+whose sequences are codon-aligned, with the ingroup haplotypes
+filterable by sample-name pattern and the outgroup species
+filterable separately---i.e., exactly the input format
+``mkado batch`` expects.
+
+Indels in the alignment are preserved (they remain as gap
+characters in the output FASTA). Multi-transcript genes are
+reduced to the canonical CDS chosen by the alignment database;
+alternative transcripts are not analysed separately. The script
+we used for the human benchmark dataset
+(``data/build_mk_dataset.py`` in the source repository) can serve
+as a starting point for adapting this to other species.
+
 Next Steps
 ----------
 


### PR DESCRIPTION
## Summary

Documentation-side fixes from the G3 round-1 review (MS G3-2026-406681). Mirrors the manuscript-side work in andrewkern/mkado-paper#5.

- **`docs/installation.rst`**: removed the user-facing Linting & Formatting (ruff) section -- a developer concern, not a user concern. Added a new "Shell Completion" subsection documenting `--install-completion` / `--show-completion` and noting the feature can be slow on some shells (R2.5, R2.8).
- **`docs/batch-workflow.rst`**: added a "Per-gene vs Aggregated Modes" section that contrasts the two and explains which test uses which default (R2.9).
- **`docs/tutorial.rst`**: added a "Working with Ortholog Alignments" section that documents the polymorphism-projection procedure used to assemble the human OrthoMaM benchmark dataset, generalized to any codon-level ortholog alignment plus a coordinate-resolved VCF (R1.7).
- **`.gitignore`**: ignore the `mkado-paper/` directory (cloned alongside this tree, has its own git history).

## Test plan

- [x] `uv run sphinx-build docs docs/_build/html` builds clean
- [x] New tutorial section renders correctly
- [x] No broken cross-references introduced