### PR TITLE
docs: add FWW frequency-threshold subsection to alpha-tg page

### DIFF
--- a/docs/alpha-tg.rst
+++ b/docs/alpha-tg.rst
@@ -49,6 +49,25 @@ Example with the included Anopheles data:
 
    mkado batch examples/anopheles_batch/ -i gamb -o afun --alpha-tg
 
+Frequency-Threshold Correction (FWW)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To reduce the bias from low-frequency slightly deleterious polymorphisms,
+α_TG can be combined with a derived allele frequency cutoff
+(`Fay, Wyckoff & Wu 2001`_) by passing ``--min-freq``:
+
+.. code-block:: bash
+
+   # FWW-corrected weighted alpha: drop polymorphisms with derived AF < 0.15
+   mkado batch alignments/ -i ingroup -o outgroup --alpha-tg --min-freq 0.15
+
+The ``--min-freq`` filter is applied per gene before α_TG is computed,
+so the weighted estimator sees only the high-frequency polymorphisms.
+``--no-singletons`` is the convenience equivalent of
+``--min-freq 1/n``.
+
+.. _Fay, Wyckoff & Wu 2001: https://doi.org/10.1093/genetics/158.3.1227
+
 Output
 ------
 


### PR DESCRIPTION
## Summary

Companion to andrewkern/mkado-paper#6. Reviewer 1 point 3 asked whether α_TG could be combined with the FWW frequency-threshold correction. It already could, via `--min-freq`, but the docs didn't mention this combination.

Adds a "Frequency-Threshold Correction (FWW)" subsection to `docs/alpha-tg.rst` that:
- shows the `--alpha-tg --min-freq X` invocation
- cites Fay, Wyckoff & Wu 2001
- gives a worked example with `--min-freq 0.15`
- notes `--no-singletons` as the convenience equivalent of `--min-freq 1/n`

The R1.3 reply in the response document was overclaiming this docs work; with this PR the reply matches reality.

## Test plan

- [x] `uv run sphinx-build docs docs/_build/html` builds clean
- [x] Cross-reference Fay 2001 anchor renders