### PR TITLE
disable Typer shell completion (R2.5)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,27 +71,3 @@ After installation, verify it works:
    mkado --help
 
 You should see the help output listing available commands.
-
-Shell Completion
-----------------
-
-MKado ships with `Typer <https://typer.tiangolo.com>`_'s built-in shell
-completion. Two options on the umbrella ``mkado`` command let you
-configure it:
-
-.. code-block:: bash
-
-   # Install completion for your current shell (bash, zsh, fish, powershell)
-   mkado --install-completion
-
-   # Print the completion script without installing it
-   mkado --show-completion
-
-Restart your shell after installing.
-
-.. note::
-
-   Completion may be slow on some systems because each completion
-   request loads the full ``mkado`` Python entry point. If you find
-   the lag distracting, simply leave completion uninstalled---it does
-   not affect any other behaviour.

--- a/src/mkado/cli.py
+++ b/src/mkado/cli.py
@@ -298,11 +298,9 @@ app = typer.Typer(
     name="mkado",
     help="MKado 御門: McDonald-Kreitman test toolkit.\n\n"
     "A modern Python implementation for detecting selection using "
-    "the McDonald-Kreitman test and related methods.\n\n"
-    "Shell completion: --install-completion sets up tab completion for "
-    "your shell (bash/zsh/fish/powershell); --show-completion prints the "
-    "completion script without installing it.",
+    "the McDonald-Kreitman test and related methods.",
     no_args_is_help=True,
+    add_completion=False,
 )
 
 


### PR DESCRIPTION
## Summary

Reviewer 2 reported that shell completion was painfully slow on their system. The cause is mkado's package-import cost (scipy.stats + scipy.optimize ~600-1000ms wall on common systems), which every Tab press in completion mode pays.

Rather than ship a feature that creates a poor first-time experience for users who do install it, this PR sets `add_completion=False` on the umbrella `Typer` instance, which removes both `--install-completion` and `--show-completion` from `mkado --help`.

The companion docs change drops the "Shell Completion" subsection added in #29, since there is nothing to document.

## Test plan

- [x] `uv run mkado --help` no longer shows completion options
- [x] Full test suite (311 tests) passes
- [x] Companion paper PR (andrewkern/mkado-paper#7) updates the R2.5/R2.8 replies